### PR TITLE
Treat boundary_tags as a list consistently

### DIFF
--- a/meshmode/mesh/__init__.py
+++ b/meshmode/mesh/__init__.py
@@ -642,8 +642,8 @@ class Mesh(Record):
 
     .. attribute:: boundary_tags
 
-        A tuple of boundary tag identifiers. :class:`BTAG_ALL` and
-        :class:`BTAG_REALLY_ALL` are guranateed to exist.
+        A list of boundary tag identifiers. :class:`BTAG_ALL` and
+        :class:`BTAG_REALLY_ALL` are guaranteed to exist.
 
     .. attribute:: btag_to_index
 

--- a/meshmode/mesh/io.py
+++ b/meshmode/mesh/io.py
@@ -251,7 +251,6 @@ class GmshMeshReceiver(GmshMeshReceiverBase):
         if self.tags:
             boundary_tags += [tag for tag, dim in self.tags if
                               dim == mesh_bulk_dim-1]
-        boundary_tags = tuple(boundary_tags)
 
         # compute facial adjacency for Mesh if there is tag information
         facial_adjacency_groups = None


### PR DESCRIPTION
Documentation specifies `boundary_tags` as a tuple, but it's used in most places as a list ([example](https://github.com/inducer/meshmode/blob/6cc0de2fec2e39e25dea38035171a74d6021916a/meshmode/mesh/__init__.py#L726-L737)). This makes it officially a list.

cc @MTCam