### PR TITLE
Add conj to the ArrayContext numpy workalike

### DIFF
--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -72,6 +72,15 @@ class _BaseFakeNumpyNamespace:
 
         return obj_array_vectorized_n_args(f)
 
+    @obj_array_vectorized_n_args
+    def conjugate(self, x):
+        # NOTE: conjugate distribute over object arrays, but it looks for a
+        # `conjugate` ufunc, while some implementations only have the shorter
+        # `conj` (e.g. cl.array.Array), so this should work for everybody
+        return x.conj()
+
+    conj = conjugate
+
 
 class ArrayContext:
     """An interface that allows a :class:`Discretization` to create and interact with
@@ -217,12 +226,15 @@ class ArrayContext:
 # {{{ PyOpenCLArrayContext
 
 class _PyOpenCLFakeNumpyNamespace(_BaseFakeNumpyNamespace):
-    def __getattr__(self, name):
-        if name in ["minimum", "maximum"]:
-            import pyopencl.array as cl_array
-            return obj_array_vectorized_n_args(getattr(cl_array, name))
+    @obj_array_vectorized_n_args
+    def maximum(self, x, y):
+        import pyopencl.array as cl_array
+        return cl_array.maximum(x, y)
 
-        return super().__getattr__(name)
+    @obj_array_vectorized_n_args
+    def minimum(self, x, y):
+        import pyopencl.array as cl_array
+        return cl_array.minimum(x, y)
 
     @obj_array_vectorized_n_args
     def where(self, criterion, then, else_):

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -1596,6 +1596,7 @@ def test_array_context_np_workalike(ctx_factory):
             ("minimum", 2),
             ("maximum", 2),
             ("where", 3),
+            ("conj", 1),
             ]:
         args = [np.random.randn(discr.ndofs) for i in range(n_args)]
         ref_result = getattr(np, sym_name)(*args)


### PR DESCRIPTION
Added to handle an `DOFArray` in [pytential](https://github.com/inducer/pytential/blob/master/pytential/symbolic/execution.py#L287).

As far as I can tell, this should just work™, but the numpy ufunc stuff looks for `conjugate` and the `cl.array.Array` only has a `conj` (i.e. this works fine for object arrays of `ndarray`). This kind of sounds like a bug, since at the toplevel `np.conj` is an alias of `np.conjugate`.