### PR TITLE
Add missing space in array context docs

### DIFF
--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -257,6 +257,7 @@ class PyOpenCLArrayContext(ArrayContext):
         A :class:`pyopencl.CommandQueue`.
 
     .. attribute:: allocator
+
         A PyOpenCL memory allocator. Can also be `None` (default) or `False` to
         use the default allocator. Please note that running with the default
         allocator allocates and deallocates OpenCL buffers directly. If lots


### PR DESCRIPTION
Another silly one-liner that fixes the rendering [here](https://documen.tician.de/meshmode/array.html#meshmode.array_context.PyOpenCLArrayContext.allocator).