### PR TITLE
Fix num_reference_derivative for multiple groups

### DIFF
--- a/meshmode/discretization/__init__.py
+++ b/meshmode/discretization/__init__.py
@@ -275,6 +275,7 @@ class Discretization(object):
 
     def num_reference_derivative(self, ref_axes, vec):
         actx = vec.array_context
+        ref_axes = list(ref_axes)
 
         @memoize_in(actx, (Discretization, "reference_derivative_prg"))
         def prg():

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -1541,6 +1541,13 @@ def test_mesh_multiple_groups(actx_factory, ambient_dim, visualize=False):
             error = flat_norm(bdry_f - em_bdry_f)
             assert error < 1.0e-11, error
 
+    # check some derivatives
+    import pytools
+    ref_axes = pytools.flatten([[i] for i in range(ambient_dim)])
+
+    x = thaw(actx, discr.nodes())
+    discr.num_reference_derivative(ref_axes, x[0])
+
 
 def test_array_context_np_workalike(actx_factory):
     actx = actx_factory()

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -1541,7 +1541,7 @@ def test_mesh_multiple_groups(actx_factory, ambient_dim, visualize=False):
             error = flat_norm(bdry_f - em_bdry_f)
             assert error < 1.0e-11, error
 
-    # check some derivatives
+    # check some derivatives (nb: flatten is a generator)
     import pytools
     ref_axes = pytools.flatten([[i] for i in range(ambient_dim)])
 


### PR DESCRIPTION
Managed to hit this in [pytential](https://github.com/inducer/pytential/blob/master/pytential/symbolic/execution.py#L219) when using multiple groups. That passed in a generator that got consumed by the first group.