### PR TITLE
Update write_vtk so it can handle empty data fields

### DIFF
--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -550,7 +550,7 @@ class Visualizer(object):
                             getattr(fld, dclass_field.name))
                         for dclass_field in dataclasses.fields(fld)
                         if getattr(fld, dclass_field.name) is not None)
-            else if fld is not None:
+            elif fld is not None:
                 new_names_and_fields.append((name, fld))
 
         names_and_fields = new_names_and_fields

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -540,12 +540,11 @@ class Visualizer(object):
         for name, fld in names_and_fields:
             if hasattr(type(fld), "__dataclass_fields__"):
                 import dataclasses
-                for dclass_field in dataclasses.fields(fld):
-                    field = getattr(fld, dclass_field.name)
-                    if field is not None:
-                        new_names_and_fields.append(
-                            (f"{name}_{dclass_field.name}", field)
-                        )
+                new_names_and_fields.extend(
+                        (f"{name}_{dclass_field.name}",
+                            getattr(fld, dclass_field.name))
+                        for dclass_field in dataclasses.fields(fld)
+                        if getattr(fld, dclass_field.name) is not None)
             else:
                 new_names_and_fields.append((name, fld))
 

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -550,7 +550,7 @@ class Visualizer(object):
                             getattr(fld, dclass_field.name))
                         for dclass_field in dataclasses.fields(fld)
                         if getattr(fld, dclass_field.name) is not None)
-            else:
+            else if fld is not None:
                 new_names_and_fields.append((name, fld))
 
         names_and_fields = new_names_and_fields

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -496,6 +496,11 @@ class Visualizer(object):
             *value* may also be a data class (see :mod:`dataclasses`),
             whose attributes will be inserted into the visualization
             with their names prefixed by *name*.
+            If *value* is *None*, then there is no data to write and the
+            corresponding *name* will not appear in the data file.
+            If *value* is *None*, it should be *None* collectively across all
+            ranks for parallel writes; otherwise the behavior of this routine
+            is undefined.
         :arg overwrite: If *True*, silently overwrite existing
             files.
         :arg use_high_order: Writes arbitrary order Lagrange VTK elements.

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -540,10 +540,12 @@ class Visualizer(object):
         for name, fld in names_and_fields:
             if hasattr(type(fld), "__dataclass_fields__"):
                 import dataclasses
-                new_names_and_fields.extend(
-                        (f"{name}_{dclass_field.name}",
-                            getattr(fld, dclass_field.name))
-                        for dclass_field in dataclasses.fields(fld))
+                for dclass_field in dataclasses.fields(fld):
+                    field = getattr(fld, dclass_field.name)
+                    if field is not None:
+                        new_names_and_fields.append(
+                            (f"{name}_{dclass_field.name}", field)
+                        )
             else:
                 new_names_and_fields.append((name, fld))
 


### PR DESCRIPTION
I would like to tweak `write_vtk_file` slightly so that it can handle the situation where the name_and_fields list contains an empty/None field array.

Example:
```python
# ConservedVars dataclass has 
# mass : np.ndarray = something
# energy : np.ndarray = something
# momentum : np.ndarray = something
# mass_fractions : np.ndarray = None
names_and_fields = [("cv", ConservedVars), ("foo", Bar)]
```

This PR fixes the write-time error experienced by _mirgecom_ when writing singe-component fluid solutions. 