### PR TITLE
Fix make_group_from_vertices for tensor product elements

### DIFF
--- a/meshmode/__init__.py
+++ b/meshmode/__init__.py
@@ -37,3 +37,12 @@ class DataUnavailable(Error):
 
 
 from builtins import FileExistsError  # noqa: F401
+
+
+def _acf():
+    import pyopencl as cl
+    from meshmode.array_context import PyOpenCLArrayContext
+
+    context = cl._csc()
+    queue = cl.CommandQueue(context)
+    return PyOpenCLArrayContext(queue)

--- a/meshmode/__init__.py
+++ b/meshmode/__init__.py
@@ -40,6 +40,9 @@ from builtins import FileExistsError  # noqa: F401
 
 
 def _acf():
+    """A tiny undocumented function to pass to tests that take an ``actx_factory``
+    argument when running them from the command line.
+    """
     import pyopencl as cl
     from meshmode.array_context import PyOpenCLArrayContext
 

--- a/meshmode/mesh/visualization.py
+++ b/meshmode/mesh/visualization.py
@@ -225,9 +225,9 @@ def write_vertex_vtk_file(mesh, file_name,
             3: (0, 1, 3, 2, 4, 5, 7, 6)
             }
 
-    node_nr_base = 0
+    vertex_nr_base = 0
     for egrp in mesh.groups:
-        i = np.s_[node_nr_base:node_nr_base + egrp.vertex_indices.size]
+        i = np.s_[vertex_nr_base:vertex_nr_base + egrp.vertex_indices.size]
         if isinstance(egrp, SimplexElementGroup):
             cells[i] = egrp.vertex_indices.reshape(-1)
         elif isinstance(egrp, TensorProductElementGroup):
@@ -235,7 +235,7 @@ def write_vertex_vtk_file(mesh, file_name,
         else:
             raise TypeError("unsupported group type")
 
-        node_nr_base += egrp.vertex_indices.size
+        vertex_nr_base += egrp.vertex_indices.size
 
     # }}}
 

--- a/meshmode/mesh/visualization.py
+++ b/meshmode/mesh/visualization.py
@@ -212,14 +212,39 @@ def write_vertex_vtk_file(mesh, file_name,
 
     # }}}
 
+    # {{{ create cell connectivity
+
+    cells = np.empty(
+            sum(egrp.vertex_indices.size for egrp in mesh.groups),
+            dtype=mesh.vertex_id_dtype)
+
+    # NOTE: vtk uses z-order for the linear quads
+    tensor_order = {
+            1: (0, 1),
+            2: (0, 1, 3, 2),
+            3: (0, 1, 3, 2, 4, 5, 7, 6)
+            }
+
+    node_nr_base = 0
+    for egrp in mesh.groups:
+        i = np.s_[node_nr_base:node_nr_base + egrp.vertex_indices.size]
+        if isinstance(egrp, SimplexElementGroup):
+            cells[i] = egrp.vertex_indices.reshape(-1)
+        elif isinstance(egrp, TensorProductElementGroup):
+            cells[i] = egrp.vertex_indices[:, tensor_order[egrp.dim]].reshape(-1)
+        else:
+            raise TypeError("unsupported group type")
+
+        node_nr_base += egrp.vertex_indices.size
+
+    # }}}
+
     grid = UnstructuredGrid(
             (mesh.nvertices,
                 DataArray("points",
                     mesh.vertices,
                     vector_format=VF_LIST_OF_COMPONENTS)),
-            cells=np.hstack([
-                vgrp.vertex_indices.reshape(-1)
-                for vgrp in mesh.groups]),
+            cells=cells,
             cell_types=cell_types)
 
     import os

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -26,7 +26,7 @@ import numpy.linalg as la
 
 from pytools.obj_array import make_obj_array
 
-import meshmode
+import meshmode         # noqa: F401
 from meshmode.array_context import (  # noqa
         pytest_generate_tests_for_pyopencl_array_context
         as pytest_generate_tests)

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -26,6 +26,7 @@ import numpy.linalg as la
 
 from pytools.obj_array import make_obj_array
 
+import meshmode
 from meshmode.array_context import (  # noqa
         pytest_generate_tests_for_pyopencl_array_context
         as pytest_generate_tests)
@@ -47,14 +48,6 @@ import pytest
 
 import logging
 logger = logging.getLogger(__name__)
-
-
-def acf():
-    import pyopencl as cl
-    from meshmode.array_context import PyOpenCLArrayContext
-    context = cl._csc()
-    queue = cl.CommandQueue(context)
-    return PyOpenCLArrayContext(queue)
 
 
 # {{{ circle mesh
@@ -1192,7 +1185,7 @@ def test_quad_mesh_2d(ambient_dim, filename, visualize=False):
 
         g = make_group_from_vertices(mesh.vertices,
                 grp.vertex_indices, grp.order,
-                group_factory=TensorProductElementGroup)
+                group_cls=TensorProductElementGroup)
         assert g.nodes.shape == (mesh.ambient_dim, grp.nelements, grp.nunit_nodes)
 
         groups.append(g)
@@ -1253,7 +1246,7 @@ def test_quad_single_element():
     mg = make_group_from_vertices(
             vertices,
             np.array([[0, 1, 2, 3]], dtype=np.int32),
-            30, group_factory=TensorProductElementGroup)
+            30, group_cls=TensorProductElementGroup)
 
     Mesh(vertices, [mg], nodal_adjacency=None, facial_adjacency_groups=None)
     if 0:


### PR DESCRIPTION
The resulting `nodes` were 2d even for a 2d surface embedded in 3d space.