### PR TITLE
Add abs shorthand to array context

### DIFF
--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -107,8 +107,8 @@ class _BaseFakeNumpyNamespace:
         # "conj", "conjugate",
 
         # Miscellaneous
-        "convolve", "clip", "sqrt", "cbrt", "square", "absolute", "fabs", "sign",
-        "heaviside", "maximum", "fmax", "nan_to_num",
+        "convolve", "clip", "sqrt", "cbrt", "square", "absolute", "abs", "fabs",
+        "sign", "heaviside", "maximum", "fmax", "nan_to_num",
 
         # FIXME:
         # "interp",


### PR DESCRIPTION
It's a [documented](https://numpy.org/doc/stable/reference/generated/numpy.absolute.html) shorthand for `absolute`.