### PR TITLE
Xdmf Visualizer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         -   name: "Main Script"
             run: |
                 sudo apt update
-                sudo apt install octave openmpi-bin libopenmpi-dev
+                sudo apt install octave openmpi-bin libopenmpi-dev libhdf5-dev
 
                 CONDA_ENVIRONMENT=.test-conda-env-py3.yml
                 export MPLBACKEND=Agg

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ distribute*tar.gz
 a.out
 *.vtu
 *.pvtu
+*.h5
+*.xmf
 
 .cache
 .pytest_cache

--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -23,6 +23,9 @@ dependencies:
 # for pymetis
 - pybind11
 
+# for xdmf/hdf5 visualizer
+- h5py
+
 # Only needed to make pylint succeed
 - matplotlib
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -282,6 +282,7 @@ intersphinx_mapping = {
     "https://tisaac.gitlab.io/recursivenodes/": None,
     "https://fenics.readthedocs.io/projects/fiat/en/latest/": None,
     "https://finat.github.io/FInAT/": None,
+    "h5py": ("https://docs.h5py.org/en/stable", None),
 }
 
 autoclass_content = "class"

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -821,8 +821,7 @@ class Visualizer:
 
         # {{{ write hdf5 + create xml tree
 
-        # NOTE: XDMF and/or XDMF in Paraview/VTK seems to be quite frail with
-        # a lot of setups found online just crashing it nonchalantly :(
+        # NOTE: 01-03-2021 based on Paraview 5.8.1 with (internal) VTK 8.90.0
         #
         # The current setup writes a grid for each element group. The grids
         # are completely separate, i.e. each one gets its own subset of the
@@ -832,9 +831,15 @@ class Visualizer:
         # plugin. It seems to also work with the XMDFReader (for Xdmf2) plugin,
         # but that's not very tested.
         #
-        # Tried
-        # * writing the nodes globally and then using a 'Reference' DataItem,
-        #   but that crashed Paraview on load
+        # A few nice-to-haves / improvements
+        #
+        # * writing a single grid per meshmode.Mesh. `meshio` actually does this
+        #   using the XDMF `TopologyType.Mixed`
+        # * writing object ndarrays as separate `DataItem`s. Tried this using
+        #   an Xdmf `DataItemType.Function`, but Paraview did not recognize it.
+        # * Using `Reference` DataItems to e.g. store the nodes globally on the
+        #   domain and just reference it in the individual grids. This crashed
+        #   Paraview.
 
         from pyvisfile.xdmf import (
                 XdmfUnstructuredGrid, DataArray,

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -98,6 +98,9 @@ def resample_to_numpy(conn, vec, *, stack=False, by_group=False):
         are flattened separately. This can be used to write each group as a
         separate mesh (in supporting formats).
     """
+    # "stack" exists as mainly as a workaround for Xdmf. See here:
+    # https://github.com/inducer/pyvisfile/pull/12#discussion_r550959081
+    # for (minimal) discussion.
     if isinstance(vec, np.ndarray) and vec.dtype.char == "O":
         from pytools.obj_array import obj_array_vectorize
         r = obj_array_vectorize(

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -775,6 +775,7 @@ class Visualizer:
         """Write an XDMF file (with an ``.xmf`` extension) containing the
         arrays in *names_and_fields*. The heavy data is written to binary
         HDF5 files, which requires installing :ref:`h5py <h5py:install>`.
+        Distributed memory visualization is not supported.
 
         :arg names_and_fields: a list of ``(name, array)``, where *array* is
             an array-like object (see :meth:`Visualizer.write_vtk_file`).
@@ -795,6 +796,10 @@ class Visualizer:
         if dataset_options is not None:
             dataset_defaults.update(dataset_options)
         dataset_options = dataset_defaults
+
+        if "comm" in h5_file_options \
+                or h5_file_options.get("driver", None) == "mpio":
+            raise ValueError("distributed memory visualization not supported")
 
         # {{{ hdf5
 

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -439,6 +439,7 @@ class Visualizer:
     .. automethod:: show_scalar_in_matplotlib_3d
     .. automethod:: write_vtk_file
     .. automethod:: write_parallel_vtk_file
+    .. automethod:: write_xdmf_file
     """
 
     def __init__(self, connection,
@@ -773,16 +774,16 @@ class Visualizer:
             real_only=False, overwrite=False):
         """Write an XDMF file (with an ``.xmf`` extension) containing the
         arrays in *names_and_fields*. The heavy data is written to binary
-        HDF5 files with ``h5py``.
+        HDF5 files, which requires installing :ref:`h5py <h5py:install>`.
 
         :arg names_and_fields: a list of ``(name, array)``, where *array* is
             an array-like object (see :meth:`Visualizer.write_vtk_file`).
         :arg attrs: a :class:`dict` of scalar attributes that will be saved
             in the root HDF5 group.
         :arg h5_file_options: a :class:`dict` passed directly to
-            ``h5py.File`` that allows controlling chunking, compatibility, etc.
+            :class:`h5py.File` that allows controlling chunking, compatibility, etc.
         :arg dataset_options: a :class:`dict` passed directly to
-            ``h5py.Group.create_dataset``.
+            :meth:`h5py.Group.create_dataset`.
         """
         if attrs is None:
             attrs = {}

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -775,7 +775,7 @@ class Visualizer:
         """Write an XDMF file (with an ``.xmf`` extension) containing the
         arrays in *names_and_fields*. The heavy data is written to binary
         HDF5 files, which requires installing :ref:`h5py <h5py:install>`.
-        Distributed memory visualization is not supported.
+        Distributed memory visualization is not yet supported.
 
         :arg names_and_fields: a list of ``(name, array)``, where *array* is
             an array-like object (see :meth:`Visualizer.write_vtk_file`).
@@ -799,7 +799,7 @@ class Visualizer:
 
         if "comm" in h5_file_options \
                 or h5_file_options.get("driver", None) == "mpio":
-            raise ValueError("distributed memory visualization not supported")
+            raise NotImplementedError("distributed memory visualization")
 
         # {{{ hdf5
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy
 recursivenodes
 git+https://github.com/inducer/pytools.git#egg=pytools
 git+https://github.com/inducer/gmsh_interop.git#egg=gmsh_interop
-git+https://github.com/alexfikl/pyvisfile.git@xdmf-support#egg=pyvisfile
+git+https://github.com/inducer/pyvisfile.git#egg=pyvisfile
 git+https://github.com/inducer/modepy.git#egg=modepy
 git+https://github.com/inducer/pyopencl.git#egg=pyopencl
 git+https://github.com/inducer/islpy.git#egg=islpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy
 recursivenodes
 git+https://github.com/inducer/pytools.git#egg=pytools
 git+https://github.com/inducer/gmsh_interop.git#egg=gmsh_interop
-git+https://github.com/inducer/pyvisfile.git#egg=pyvisfile
+git+https://github.com/alexfikl/pyvisfile.git@xdmf-support#egg=pyvisfile
 git+https://github.com/inducer/modepy.git#egg=modepy
 git+https://github.com/inducer/pyopencl.git#egg=pyopencl
 git+https://github.com/inducer/islpy.git#egg=islpy

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,9 @@ def main():
               "recursivenodes",
               "dataclasses; python_version<='3.6'",
               ],
+          extras_require={
+              "visualization": ["h5py"],
+              },
           )
 
 

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -213,8 +213,11 @@ def test_visualizers(actx_factory, dim, group_cls):
         vis.write_vtk_file(f"{basename}_lagrange.vtu",
                 names_and_fields, overwrite=True, use_high_order=True)
 
-    basename = f"visualizer_xdmf_{eltype}_{dim}d"
-    vis.write_xdmf_file(f"{basename}.xmf", names_and_fields, overwrite=True)
+    try:
+        basename = f"visualizer_xdmf_{eltype}_{dim}d"
+        vis.write_xdmf_file(f"{basename}.xmf", names_and_fields, overwrite=True)
+    except ImportError:
+        logger.info("h5py not available")
 
     if mesh.dim == 2 and is_simplex:
         try:
@@ -226,7 +229,7 @@ def test_visualizers(actx_factory, dim, group_cls):
         try:
             vis.show_scalar_in_mayavi(f, do_show=False)
         except ImportError:
-            logger.info("mayavi not avaiable")
+            logger.info("mayavi not available")
 
     vis = make_visualizer(actx, discr, target_order,
             force_equidistant=True)

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -196,17 +196,16 @@ def test_visualizers(actx_factory, dim, group_cls):
     from meshmode.discretization.visualization import make_visualizer
     vis = make_visualizer(actx, discr, target_order)
 
-    if is_simplex:
-        basename = f"visualizer_vtk_simplex_{dim}d"
-    else:
-        basename = f"visualizer_vtk_box_{dim}d"
-
-    vis.write_vtk_file(f"{basename}_linear.vtu",
-            [("f", f)], overwrite=True)
+    eltype = "simplex" if is_simplex else "box"
+    basename = f"visualizer_vtk_{eltype}_{dim}d"
+    vis.write_vtk_file(f"{basename}_linear.vtu", [("f", f)], overwrite=True)
 
     with pytest.raises(RuntimeError):
         vis.write_vtk_file(f"{basename}_lagrange.vtu",
                 [("f", f)], overwrite=True, use_high_order=True)
+
+    basename = f"visualizer_xdmf_{eltype}_{dim}d"
+    vis.write_xdmf_file(f"{basename}.xmf", [("f", f)], overwrite=True)
 
     if mesh.dim == 2 and is_simplex:
         try:
@@ -222,6 +221,8 @@ def test_visualizers(actx_factory, dim, group_cls):
 
     vis = make_visualizer(actx, discr, target_order,
             force_equidistant=True)
+
+    basename = f"visualizer_vtk_{eltype}_{dim}d"
     vis.write_vtk_file(f"{basename}_lagrange.vtu",
             [("f", f)], overwrite=True, use_high_order=True)
 


### PR DESCRIPTION
Uses inducer/pyvisfile#12 to write out some XDMF + HDF5 files (requires h5py of course). It reuses the linear VTK connectivity but I had to write one XDMF Grid per group because I couldn't convince Paraview to index into arrays properly.

One nice benefit of these things is that HDF5 seems to be quite a bit better at compression. From running `test_meshmode.py::test_visualizers`:
```
>> ls -lSh
2.0M Dec 30 20:27 visualizer_vtk_simplex_3d_linear.vtu
846K Dec 30 20:27 visualizer_vtk_simplex_3d_lagrange.vtu
286K Dec 30 20:27 visualizer_xdmf_simplex_3d.h5
1.3K Dec 30 20:27 visualizer_xdmf_simplex_3d.xmf
```