### PR TITLE
Add some in-place operators to DOFArray

### DIFF
--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -108,7 +108,9 @@ class DOFArray:
         :class:`DOFArray` instances support elementwise ``<``, ``>``,
         ``<=``, ``>=``. (:mod:`numpy` object arrays containing arrays do not.)
 
-    Basic in-place operations are also supported.
+    Basic in-place operations are also supported. Note that not all array types provided
+    by :class:`meshmode.array_context.ArrayContext` implementations support
+    in-place operations. Those based on lazy evaluation are a salient example.
 
     .. automethod:: __iadd__
     .. automethod:: __isub__

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -108,9 +108,10 @@ class DOFArray:
         :class:`DOFArray` instances support elementwise ``<``, ``>``,
         ``<=``, ``>=``. (:mod:`numpy` object arrays containing arrays do not.)
 
-    Basic in-place operations are also supported. Note that not all array types provided
-    by :class:`meshmode.array_context.ArrayContext` implementations support
-    in-place operations. Those based on lazy evaluation are a salient example.
+    Basic in-place operations are also supported. Note that not all array types
+    provided by :class:`meshmode.array_context.ArrayContext` implementations
+    support in-place operations. Those based on lazy evaluation are a salient
+    example.
 
     .. automethod:: __iadd__
     .. automethod:: __isub__

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -114,6 +114,9 @@ class DOFArray:
     .. automethod:: __isub__
     .. automethod:: __imul__
     .. automethod:: __itruediv__
+    .. automethod:: __iand__
+    .. automethod:: __ixor__
+    .. automethod:: __ior__
 
     .. note::
 
@@ -284,6 +287,7 @@ class DOFArray:
     def __isub__(self, arg): return self._ibop(op.isub, arg)            # noqa: E704
     def __imul__(self, arg): return self._ibop(op.imul, arg)            # noqa: E704
     def __itruediv__(self, arg): return self._ibop(op.itruediv, arg)    # noqa: E704
+    def __imod__(self, arg): return self._ibop(op.imod, arg)            # noqa: E704
 
     # }}}
 
@@ -306,6 +310,10 @@ class DOFArray:
     def __rand__(self, arg): return self._bop(operator.and_, arg, self)  # noqa: E704
     def __rxor__(self, arg): return self._bop(operator.xor, arg, self)  # noqa: E704
     def __ror__(self, arg): return self._bop(operator.or_, arg, self)  # noqa: E704
+
+    def __iand__(self, arg): return self._ibop(op.iand, arg)        # noqa: E704
+    def __ixor__(self, arg): return self._ibop(op.ixor, arg)        # noqa: E704
+    def __ior__(self, arg): return self._ibop(op.ior, arg)          # noqa: E704
 
     # }}}
 

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -89,12 +89,31 @@ class DOFArray:
     .. automethod:: __len__
     .. automethod:: __getitem__
 
+    The following methods and attributes are implemented to mimic the
+    functionality of :class:`~numpy.ndarray`\ s. They require the
+    :class:`DOFArray` to be :func:`thaw`\ ed.
+
+    .. attribute:: shape
+    .. attribute:: size
+    .. automethod:: copy
+    .. automethod:: fill
+    .. automethod:: conj
+    .. attribute:: real
+    .. attribute:: imag
+
     This object supports arithmetic, comparisons, and logic operators.
 
     .. note::
 
         :class:`DOFArray` instances support elementwise ``<``, ``>``,
         ``<=``, ``>=``. (:mod:`numpy` object arrays containing arrays do not.)
+
+    Basic in-place operations are also supported.
+
+    .. automethod:: __iadd__
+    .. automethod:: __isub__
+    .. automethod:: __imul__
+    .. automethod:: __itruediv__
 
     .. note::
 
@@ -198,6 +217,7 @@ class DOFArray:
     # {{{ arithmetic
 
     def _ibop(self, f, arg):
+        """Generic in-place binary operator without any broadcast support."""
         if isinstance(arg, DOFArray):
             if len(self) != len(arg):
                 raise ValueError("'DOFArray' objects in binary operator must "
@@ -255,7 +275,12 @@ class DOFArray:
     def __neg__(self): return self._like_me([-self_i for self_i in self._data])  # noqa: E704, E501
     def __abs__(self): return self._like_me([abs(self_i) for self_i in self._data])  # noqa: E704, E501
 
-    def __iadd__(self, arg): return self._ibop(op.iadd, arg)            # noqa: E704
+    def __iadd__(self, arg):
+        """
+        :param arg: can be a :class:`~numbers.Number` or another :class:`DOFArray`.
+        """
+        return self._ibop(op.iadd, arg)
+
     def __isub__(self, arg): return self._ibop(op.isub, arg)            # noqa: E704
     def __imul__(self, arg): return self._ibop(op.imul, arg)            # noqa: E704
     def __itruediv__(self, arg): return self._ibop(op.itruediv, arg)    # noqa: E704

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -108,6 +108,8 @@ def test_dof_array_arithmetic_same_as_numpy(actx_factory):
             # FIXME pyopencl.Array doesn't do mod.
             #(operator.mod, 2, True),
             #(operator.mod, 2, False),
+            #(operator.imod, 2, True),
+            #(operator.imod, 2, False),
             # FIXME: Two outputs
             #(divmod, 2, False),
 
@@ -120,7 +122,10 @@ def test_dof_array_arithmetic_same_as_numpy(actx_factory):
             (operator.xor, 2, True),
             (operator.or_, 2, True),
 
-            (operator.le, 2, False),
+            (operator.iand, 2, True),
+            (operator.ixor, 2, True),
+            (operator.ior, 2, True),
+
             (operator.ge, 2, False),
             (operator.lt, 2, False),
             (operator.gt, 2, False),
@@ -142,7 +147,7 @@ def test_dof_array_arithmetic_same_as_numpy(actx_factory):
             if is_array_flags[0] == 0 and op_func in [
                     operator.iadd, operator.isub,
                     operator.imul, operator.itruediv,
-                    operator.ipow,
+                    operator.iand, operator.ixor, operator.ior,
                     ]:
                 # can't do in place operations with a scalar lhs
                 continue
@@ -197,7 +202,7 @@ def test_dof_array_arithmetic_same_as_numpy(actx_factory):
 
                     operator.iadd, operator.isub,
                     operator.imul, operator.itruediv,
-                    operator.ipow,
+                    operator.iand, operator.ixor, operator.ior,
 
                     # All Python objects are real-valued, right?
                     get_imag,


### PR DESCRIPTION
Added `iadd`, `isub`, `imul` and `itruediv`. There's some more in `cl.Array` that could be added, but I mostly just needed these.