### PR TITLE
Compute facial adjacency with numpy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,11 +114,9 @@ jobs:
     downstream_tests:
         strategy:
             matrix:
-                # Reinstate when
+                # FIXME Reinstate when
                 # https://github.com/illinois-ceesd/mirgecom/issues/212
                 # is fixed:
-                # downstream_project: [grudge, pytential, mirgecom]
-
                 downstream_project: [grudge, pytential]
         name: Tests for downstream project ${{ matrix.downstream_project }}
         runs-on: ubuntu-latest

--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
 - python=3
 - git
+- libhwloc=2
 - numpy
 - pocl
 - mako

--- a/meshmode/mesh/__init__.py
+++ b/meshmode/mesh/__init__.py
@@ -1163,17 +1163,18 @@ def _compute_facial_adjacency_from_vertices(groups, boundary_tags,
                 face_nr_base+grp.nelements]
             has_neighbor = adj_indices >= 0
             neighbor_adj_indices = adj_indices[has_neighbor]
-            ids = face_ids[nvertices]
+            neighbor_igrps = face_ids[nvertices][0, neighbor_adj_indices]
+            neighbor_fids = face_ids[nvertices][1, neighbor_adj_indices]
             adj = _FlatFacialAdjacencyData(grp.nelements,
                 element_id_dtype=element_id_dtype, face_id_dtype=face_id_dtype)
             adj.elements = np.indices((grp.nelements,), dtype=element_id_dtype)
             adj.element_faces[:] = fid
             adj.neighbor_groups[:] = -1
-            adj.neighbor_groups[has_neighbor] = ids[0, neighbor_adj_indices]
+            adj.neighbor_groups[has_neighbor] = neighbor_igrps
             adj.neighbor_faces[:] = 0
-            adj.neighbor_faces[has_neighbor] = ids[1, neighbor_adj_indices]
+            adj.neighbor_faces[has_neighbor] = neighbor_fids
             adj.neighbors[has_neighbor] = neighbor_adj_indices - face_nr_bases[
-                ids[0, neighbor_adj_indices], ids[1, neighbor_adj_indices]]
+                neighbor_igrps, neighbor_fids]
             adj.neighbors[~has_neighbor] = -(
                     boundary_tag_bit(BTAG_ALL)
                     | boundary_tag_bit(BTAG_REALLY_ALL))

--- a/meshmode/mesh/__init__.py
+++ b/meshmode/mesh/__init__.py
@@ -1123,11 +1123,11 @@ def _compute_facial_adjacency_from_vertices(groups, boundary_tags,
             nvertices = len(ref_fvi)
             face_nr_base = face_nr_bases[igrp, fid]
             grp_fvi = grp.vertex_indices[:, ref_fvi]
-            vertex_indices = face_vertex_indices[nvertices]
-            ids = face_ids[nvertices]
-            vertex_indices[:, face_nr_base:face_nr_base+grp.nelements] = grp_fvi.T
-            ids[0, face_nr_base:face_nr_base+grp.nelements] = igrp
-            ids[1, face_nr_base:face_nr_base+grp.nelements] = fid
+            istart = face_nr_base
+            iend = face_nr_base + grp.nelements
+            face_vertex_indices[nvertices][:, istart:iend] = grp_fvi.T
+            face_ids[nvertices][0, istart:iend] = igrp
+            face_ids[nvertices][1, istart:iend] = fid
 
     del igrp
     del grp

--- a/meshmode/mesh/__init__.py
+++ b/meshmode/mesh/__init__.py
@@ -1060,7 +1060,7 @@ class _FlatFacialAdjacencyData:
 
     .. attribute:: elements
 
-        The group-relative element index. (Defau
+        The group-relative element index.
 
     .. attribute:: element_faces
 

--- a/meshmode/mesh/__init__.py
+++ b/meshmode/mesh/__init__.py
@@ -1068,7 +1068,7 @@ class _FlatFacialAdjacencyData:
 
     .. attribute:: neighbor_groups
 
-        The group containing the adjacent element.
+        The group containing the adjacent element, or -1 if the face is not shared.
 
     .. attribute:: neighbors
 
@@ -1170,7 +1170,7 @@ def _compute_facial_adjacency_from_vertices(groups, boundary_tags,
             adj.element_faces[:] = fid
             adj.neighbor_groups[:] = -1
             adj.neighbor_groups[has_neighbor] = ids[0, neighbor_adj_indices]
-            adj.neighbor_faces[:] = -1
+            adj.neighbor_faces[:] = 0
             adj.neighbor_faces[has_neighbor] = ids[1, neighbor_adj_indices]
             adj.neighbors[has_neighbor] = neighbor_adj_indices - face_nr_bases[
                 ids[0, neighbor_adj_indices], ids[1, neighbor_adj_indices]]


### PR DESCRIPTION
Rewrites `_compute_facial_adjacency_from_vertices` using numpy in order to try to fix illinois-ceesd/mirgecom#202.