### PR TITLE
Add a copy method to Discretization

### DIFF
--- a/meshmode/discretization/__init__.py
+++ b/meshmode/discretization/__init__.py
@@ -216,6 +216,15 @@ class Discretization:
                 }[self.real_dtype.type])
 
         self._setup_actx = actx
+        self._group_factory = group_factory
+
+    def copy(self, actx=None, mesh=None, group_factory=None, real_dtype=None):
+        return type(self)(
+                self._setup_actx if actx is None else actx,
+                self.mesh if mesh is None else mesh,
+                self._group_factory if group_factory is None else group_factory,
+                self.real_dtype if real_dtype is None else real_dtype,
+                )
 
     @property
     def dim(self):

--- a/meshmode/discretization/__init__.py
+++ b/meshmode/discretization/__init__.py
@@ -174,6 +174,7 @@ class Discretization:
 
     .. attribute :: groups
 
+    .. automethod:: copy
     .. automethod:: empty
     .. automethod:: zeros
     .. automethod:: empty_like
@@ -219,6 +220,11 @@ class Discretization:
         self._group_factory = group_factory
 
     def copy(self, actx=None, mesh=None, group_factory=None, real_dtype=None):
+        """Creates a new object of the same type with all arguments that are not
+        *None* replaced. The copy is not recursive (e.g. it does not call
+        :meth:`meshmode.mesh.Mesh.copy`).
+        """
+
         return type(self)(
                 self._setup_actx if actx is None else actx,
                 self.mesh if mesh is None else mesh,

--- a/meshmode/discretization/connection/face.py
+++ b/meshmode/discretization/connection/face.py
@@ -340,9 +340,10 @@ def make_face_restriction(actx, discr, group_factory, boundary_tag,
 
     bdry_mesh = Mesh(bdry_vertices, bdry_mesh_groups)
 
-    from meshmode.discretization import Discretization
-    bdry_discr = Discretization(
-            actx, bdry_mesh, group_factory)
+    bdry_discr = discr.copy(
+            actx=actx,
+            mesh=bdry_mesh,
+            group_factory=group_factory)
 
     connection = _build_boundary_connection(
             actx, discr, bdry_discr, connection_data,

--- a/meshmode/discretization/connection/refinement.py
+++ b/meshmode/discretization/connection/refinement.py
@@ -137,12 +137,11 @@ def make_refinement_connection(actx, refiner, coarse_discr, group_factory):
         raise ValueError(
             "coarse_discr does not live on the same mesh given to the refiner")
 
-    from meshmode.discretization import Discretization
-    fine_discr = Discretization(
-        actx,
-        fine_mesh,
-        group_factory,
-        real_dtype=coarse_discr.real_dtype)
+    fine_discr = coarse_discr.copy(
+        actx=actx,
+        mesh=fine_mesh,
+        group_factory=group_factory,
+        )
 
     groups = []
     for group_idx, (coarse_discr_group, fine_discr_group, record) in \

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -1003,7 +1003,7 @@ def make_visualizer(actx, discr, vis_order,
         equidistant nodes. If plotting high-order Lagrange VTK elements, this
         needs to be set to *True*.
     """
-    from meshmode.discretization import Discretization
+    from meshmode.discretization.poly_element import OrderAndTypeBasedGroupFactory
 
     if force_equidistant:
         from meshmode.discretization.poly_element import (
@@ -1014,14 +1014,13 @@ def make_visualizer(actx, discr, vis_order,
                 PolynomialWarpAndBlendElementGroup as SimplexElementGroup,
                 LegendreGaussLobattoTensorProductElementGroup as TensorElementGroup)
 
-    from meshmode.discretization.poly_element import OrderAndTypeBasedGroupFactory
-    vis_discr = Discretization(
-            actx, discr.mesh,
-            OrderAndTypeBasedGroupFactory(
+    vis_discr = discr.copy(
+            actx=actx,
+            group_factory=OrderAndTypeBasedGroupFactory(
                 vis_order,
                 simplex_group_class=SimplexElementGroup,
                 tensor_product_group_class=TensorElementGroup),
-            real_dtype=discr.real_dtype)
+            )
 
     from meshmode.discretization.connection import \
             make_same_mesh_connection

--- a/meshmode/distributed.py
+++ b/meshmode/distributed.py
@@ -205,17 +205,16 @@ class MPIBoundaryCommSetupHelper:
         logger.debug("rank %d: Received rank %d data",
                      self.i_local_part, self.i_remote_part)
 
-        from meshmode.discretization import Discretization
-
         # Connect local_mesh to remote_mesh
         from meshmode.discretization.connection import make_partition_connection
         remote_to_local_bdry_conn = make_partition_connection(
                 self.array_context,
                 local_bdry_conn=self.local_bdry_conn,
                 i_local_part=self.i_local_part,
-                remote_bdry_discr=Discretization(
-                    self.array_context, remote_bdry_mesh,
-                    self.bdry_grp_factory),
+                remote_bdry_discr=self.local_bdry_conn.to_discr.copy(
+                    actx=self.array_context,
+                    mesh=remote_bdry_mesh,
+                    group_factory=self.bdry_grp_factory),
                 remote_group_infos=remote_group_infos)
 
         self.send_req.wait()

--- a/meshmode/mesh/__init__.py
+++ b/meshmode/mesh/__init__.py
@@ -662,6 +662,7 @@ class Mesh(Record):
         *False* if it is known that some element interfaces are non-conforming.
         *None* if neither of the two is known.
 
+    .. automethod:: copy
     .. automethod:: __eq__
     .. automethod:: __ne__
     """


### PR DESCRIPTION
Address the first (and simplest) point from #123.

I went with copy instead of replace because similar classes are based on `pytools.Record` and it uses copy.