### PR TITLE
Test for mesh with interior nodes

### DIFF
--- a/meshmode/mesh/__init__.py
+++ b/meshmode/mesh/__init__.py
@@ -1085,7 +1085,7 @@ class _FlatFacialAdjacencyData:
     def __init__(self, nfaces, element_id_dtype, face_id_dtype):
         self.elements = np.empty(nfaces, dtype=element_id_dtype)
         self.element_faces = np.empty(nfaces, dtype=face_id_dtype)
-        self.neighbor_groups = np.empty(nfaces, dtype=np.int)
+        self.neighbor_groups = np.empty(nfaces, dtype=np.int64)
         self.neighbors = np.empty(nfaces, dtype=element_id_dtype)
         self.neighbor_faces = np.empty(nfaces, dtype=face_id_dtype)
 

--- a/meshmode/mesh/generation.py
+++ b/meshmode/mesh/generation.py
@@ -396,7 +396,7 @@ def make_group_from_vertices(vertices, vertex_indices, order,
 
 # {{{ generate_icosahedron
 
-def generate_icosahedron(r, order):
+def generate_icosahedron(r, order, unit_nodes=None):
     # https://en.wikipedia.org/w/index.php?title=Icosahedron&oldid=387737307
 
     phi = (1+5**(1/2))/2
@@ -426,7 +426,8 @@ def generate_icosahedron(r, order):
 
     vertex_indices = np.array(tris, dtype=np.int32)
 
-    grp = make_group_from_vertices(vertices, vertex_indices, order)
+    grp = make_group_from_vertices(vertices, vertex_indices, order,
+            unit_nodes=unit_nodes)
 
     from meshmode.mesh import Mesh
     return Mesh(
@@ -438,8 +439,8 @@ def generate_icosahedron(r, order):
 
 # {{{ generate_icosphere
 
-def generate_icosphere(r, order, uniform_refinement_rounds=0):
-    mesh = generate_icosahedron(r, order)
+def generate_icosphere(r, order, uniform_refinement_rounds=0, unit_nodes=None):
+    mesh = generate_icosahedron(r, order, unit_nodes=unit_nodes)
 
     if uniform_refinement_rounds:
         # These come out conforming, so we're OK to use the faster refiner.
@@ -466,7 +467,8 @@ def generate_icosphere(r, order, uniform_refinement_rounds=0):
 # {{{ generate_torus_and_cycle_vertices
 
 def generate_torus_and_cycle_vertices(r_major, r_minor,
-        n_major=20, n_minor=10, order=1):
+        n_major=20, n_minor=10, order=1,
+        unit_nodes=None):
     a = r_major
     b = r_minor
     u, v = np.mgrid[0:2*np.pi:2*np.pi/n_major, 0:2*np.pi:2*np.pi/n_minor]
@@ -486,7 +488,8 @@ def generate_torus_and_cycle_vertices(r_major, r_minor,
             for i in range(n_major) for j in range(n_minor)])
 
     vertex_indices = np.array(vertex_indices, dtype=np.int32)
-    grp = make_group_from_vertices(vertices, vertex_indices, order)
+    grp = make_group_from_vertices(vertices, vertex_indices, order,
+            unit_nodes=unit_nodes)
 
     # ambient_dim, nelements, nunit_nodes
     nodes = grp.nodes.copy()
@@ -530,7 +533,8 @@ def generate_torus_and_cycle_vertices(r_major, r_minor,
 # }}}
 
 
-def generate_torus(r_major, r_minor, n_major=20, n_minor=10, order=1):
+def generate_torus(r_major, r_minor, n_major=20, n_minor=10, order=1,
+        unit_nodes=None):
     r"""Generate a torus.
 
     .. figure:: images/torus.png
@@ -564,7 +568,8 @@ def generate_torus(r_major, r_minor, n_major=20, n_minor=10, order=1):
 
     """
     mesh, a_cycle, b_cycle = generate_torus_and_cycle_vertices(
-            r_major, r_minor, n_major, n_minor, order)
+            r_major, r_minor, n_major, n_minor, order,
+            unit_nodes=unit_nodes)
     return mesh
 
 

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -304,7 +304,6 @@ def test_box_boundary_tags(dim, nelem, mesh_type, group_cls, visualize=False):
     if group_cls is TensorProductElementGroup and mesh_type is not None:
         pytest.skip("mesh type not supported on tensor product elements")
 
-    from meshmode.mesh.generation import generate_regular_rect_mesh
     from meshmode.mesh import is_boundary_tag_empty
     from meshmode.mesh import check_bc_coverage
 
@@ -326,7 +325,7 @@ def test_box_boundary_tags(dim, nelem, mesh_type, group_cls, visualize=False):
         n = (nelem, nelem, nelem)
         btag_to_face = {"btag_test_1": ["+x", "-y", "-z"],
                         "btag_test_2": ["+y", "-x", "+z"]}
-    mesh = generate_regular_rect_mesh(a=a, b=b,
+    mesh = mgen.generate_regular_rect_mesh(a=a, b=b,
                                       n=n, order=3,
                                       boundary_tag_to_face=btag_to_face,
                                       group_cls=group_cls,
@@ -454,15 +453,13 @@ def test_boundary_interpolation(actx_factory, group_factory, boundary_tag,
                     "blob2d-order%d-h%s.msh" % (order, mesh_par),
                     force_ambient_dim=2)
         elif mesh_name == "warp":
-            from meshmode.mesh.generation import generate_warped_rect_mesh
-            mesh = generate_warped_rect_mesh(dim, order=order, n=mesh_par,
+            mesh = mgen.generate_warped_rect_mesh(dim, order=order, n=mesh_par,
                     group_cls=group_cls)
 
             h = 1/mesh_par
 
         elif mesh_name == "rect":
-            from meshmode.mesh.generation import generate_regular_rect_mesh
-            mesh = generate_regular_rect_mesh(a=(0,)*dim, b=(1,)*dim,
+            mesh = mgen.generate_regular_rect_mesh(a=(0,)*dim, b=(1,)*dim,
                     order=order, n=(mesh_par,)*dim, group_cls=group_cls)
 
             h = 1/mesh_par
@@ -568,8 +565,7 @@ def test_all_faces_interpolation(actx_factory, group_factory,
                     )
             print("END GEN")
         elif mesh_name == "warp":
-            from meshmode.mesh.generation import generate_warped_rect_mesh
-            mesh = generate_warped_rect_mesh(dim, order=4, n=mesh_par,
+            mesh = mgen.generate_warped_rect_mesh(dim, order=4, n=mesh_par,
                     group_cls=group_cls)
 
             h = 1/mesh_par
@@ -679,8 +675,7 @@ def test_opposite_face_interpolation(actx_factory, group_factory,
         if mesh_name == "segment":
             assert dim == 1
 
-            from meshmode.mesh.generation import generate_box_mesh
-            mesh = generate_box_mesh(
+            mesh = mgen.generate_box_mesh(
                     [np.linspace(-0.5, 0.5, mesh_par)],
                     order=order,
                     group_cls=group_cls)
@@ -701,8 +696,7 @@ def test_opposite_face_interpolation(actx_factory, group_factory,
                     )
             print("END GEN")
         elif mesh_name == "warp":
-            from meshmode.mesh.generation import generate_warped_rect_mesh
-            mesh = generate_warped_rect_mesh(dim, order=order, n=mesh_par,
+            mesh = mgen.generate_warped_rect_mesh(dim, order=order, n=mesh_par,
                     group_cls=group_cls)
 
             h = 1/mesh_par
@@ -1149,8 +1143,7 @@ def test_sanity_balls(actx_factory, src_file, dim, mesh_order, visualize=False):
 # {{{ rect/box mesh generation
 
 def test_rect_mesh(visualize=False):
-    from meshmode.mesh.generation import generate_regular_rect_mesh
-    mesh = generate_regular_rect_mesh()
+    mesh = mgen.generate_regular_rect_mesh()
 
     if visualize:
         from meshmode.mesh.visualization import draw_2d_mesh
@@ -1160,8 +1153,7 @@ def test_rect_mesh(visualize=False):
 
 
 def test_box_mesh(actx_factory, visualize=False):
-    from meshmode.mesh.generation import generate_box_mesh
-    mesh = generate_box_mesh(3*(np.linspace(0, 1, 5),))
+    mesh = mgen.generate_box_mesh(3*(np.linspace(0, 1, 5),))
 
     if visualize:
         from meshmode.discretization import Discretization
@@ -1180,16 +1172,14 @@ def test_box_mesh(actx_factory, visualize=False):
 
 
 def test_mesh_copy():
-    from meshmode.mesh.generation import generate_box_mesh
-    mesh = generate_box_mesh(3*(np.linspace(0, 1, 5),))
+    mesh = mgen.generate_box_mesh(3*(np.linspace(0, 1, 5),))
     mesh.copy()
 
 
 # {{{ as_python stringification
 
 def test_as_python():
-    from meshmode.mesh.generation import generate_box_mesh
-    mesh = generate_box_mesh(3*(np.linspace(0, 1, 5),))
+    mesh = mgen.generate_box_mesh(3*(np.linspace(0, 1, 5),))
 
     # These implicitly compute these adjacency structures.
     mesh.nodal_adjacency
@@ -1212,8 +1202,7 @@ def test_as_python():
 # {{{ test lookup tree for element finding
 
 def test_lookup_tree(visualize=False):
-    from meshmode.mesh.generation import make_curve_mesh, cloverleaf
-    mesh = make_curve_mesh(cloverleaf, np.linspace(0, 1, 1000), order=3)
+    mesh = mgen.make_curve_mesh(mgen.cloverleaf, np.linspace(0, 1, 1000), order=3)
 
     from meshmode.mesh.tools import make_element_lookup_tree
     tree = make_element_lookup_tree(mesh)
@@ -1262,7 +1251,6 @@ def test_quad_mesh_2d(ambient_dim, filename, visualize=False):
     logger.info("END GEN")
     logger.info("nelements: %d", mesh.nelements)
 
-    from meshmode.mesh.generation import make_group_from_vertices
     groups = []
     for grp in mesh.groups:
         if not isinstance(grp, TensorProductElementGroup):
@@ -1271,7 +1259,7 @@ def test_quad_mesh_2d(ambient_dim, filename, visualize=False):
             groups.append(grp.copy())
             continue
 
-        g = make_group_from_vertices(mesh.vertices,
+        g = mgen.make_group_from_vertices(mesh.vertices,
                 grp.vertex_indices, grp.order,
                 group_cls=TensorProductElementGroup)
         assert g.nodes.shape == (mesh.ambient_dim, grp.nelements, grp.nunit_nodes)
@@ -1354,15 +1342,13 @@ def test_quad_mesh_3d(mesh_name, order=3, visualize=False):
 # {{{ test_quad_single_element
 
 def test_quad_single_element(visualize=False):
-    from meshmode.mesh.generation import make_group_from_vertices
-
     vertices = np.array([
                 [0.91, 1.10],
                 [2.64, 1.27],
                 [0.97, 2.56],
                 [3.00, 3.41],
                 ]).T
-    mg = make_group_from_vertices(
+    mg = mgen.make_group_from_vertices(
             vertices,
             np.array([[0, 1, 2, 3]], dtype=np.int32),
             30, group_cls=TensorProductElementGroup)
@@ -1381,8 +1367,7 @@ def test_quad_single_element(visualize=False):
 # {{{ test_quad_multi_element
 
 def test_quad_multi_element(visualize=False):
-    from meshmode.mesh.generation import generate_box_mesh
-    mesh = generate_box_mesh(
+    mesh = mgen.generate_box_mesh(
             (
                 np.linspace(3, 8, 4),
                 np.linspace(3, 8, 4),
@@ -1424,8 +1409,7 @@ def test_vtk_overwrite(actx_factory):
     actx = actx_factory()
     target_order = 7
 
-    from meshmode.mesh.generation import generate_torus
-    mesh = generate_torus(10.0, 2.0, order=target_order)
+    mesh = mgen.generate_torus(10.0, 2.0, order=target_order)
 
     from meshmode.discretization import Discretization
     from meshmode.discretization.poly_element import \
@@ -1494,8 +1478,7 @@ def test_mesh_without_vertices(actx_factory):
     actx = actx_factory()
 
     # create a mesh
-    from meshmode.mesh.generation import generate_icosphere
-    mesh = generate_icosphere(r=1.0, order=4)
+    mesh = mgen.generate_icosphere(r=1.0, order=4)
 
     # create one without the vertices
     from meshmode.mesh import Mesh
@@ -1527,9 +1510,7 @@ def test_open_curved_mesh(curve_name):
             ])
 
     if curve_name == "ellipse":
-        from functools import partial
-        from meshmode.mesh.generation import ellipse
-        curve_f = partial(ellipse, 2.0)
+        curve_f = partial(mgen.ellipse, 2.0)
         closed = True
     elif curve_name == "arc":
         curve_f = arc_curve
@@ -1537,18 +1518,16 @@ def test_open_curved_mesh(curve_name):
     else:
         raise ValueError("unknown curve")
 
-    from meshmode.mesh.generation import make_curve_mesh
     nelements = 32
     order = 4
-    make_curve_mesh(curve_f,
+    mgen.make_curve_mesh(curve_f,
             np.linspace(0.0, 1.0, nelements + 1),
             order=order,
             closed=closed)
 
 
 def _generate_cross_warped_rect_mesh(dim, order, n):
-    from meshmode.mesh.generation import generate_regular_rect_mesh
-    mesh = generate_regular_rect_mesh(
+    mesh = mgen.generate_regular_rect_mesh(
             a=(0,)*dim, b=(1,)*dim,
             n=(n,)*dim, order=order)
 
@@ -1569,44 +1548,39 @@ def _generate_cross_warped_rect_mesh(dim, order, n):
     "sphere", "torus"
     ])
 def test_is_affine_group_check(mesh_name):
-    from meshmode.mesh.generation import (
-            generate_regular_rect_mesh, generate_warped_rect_mesh,
-            make_curve_mesh, ellipse,
-            generate_icosphere, generate_torus)
-
     order = 4
     nelements = 16
 
     if mesh_name.startswith("box"):
         dim = int(mesh_name[-2])
         is_affine = True
-        mesh = generate_regular_rect_mesh(
+        mesh = mgen.generate_regular_rect_mesh(
                 a=(-0.5,)*dim, b=(0.5,)*dim,
                 n=(nelements,)*dim, order=order)
     elif mesh_name.startswith("warped_box"):
         dim = int(mesh_name[-2])
         is_affine = False
-        mesh = generate_warped_rect_mesh(dim, order, nelements)
+        mesh = mgen.generate_warped_rect_mesh(dim, order, nelements)
     elif mesh_name == "cross_warped_box":
         dim = 2
         is_affine = False
         mesh = _generate_cross_warped_rect_mesh(dim, order, nelements)
     elif mesh_name == "circle":
         is_affine = False
-        mesh = make_curve_mesh(
-                lambda t: ellipse(1.0, t),
+        mesh = mgen.make_curve_mesh(
+                lambda t: mgen.ellipse(1.0, t),
                 np.linspace(0.0, 1.0, nelements + 1), order=order)
     elif mesh_name == "ellipse":
         is_affine = False
-        mesh = make_curve_mesh(
-                lambda t: ellipse(2.0, t),
+        mesh = mgen.make_curve_mesh(
+                lambda t: mgen.ellipse(2.0, t),
                 np.linspace(0.0, 1.0, nelements + 1), order=order)
     elif mesh_name == "sphere":
         is_affine = False
-        mesh = generate_icosphere(r=1.0, order=order)
+        mesh = mgen.generate_icosphere(r=1.0, order=order)
     elif mesh_name == "torus":
         is_affine = False
-        mesh = generate_torus(10.0, 2.0, order=order)
+        mesh = mgen.generate_torus(10.0, 2.0, order=order)
     else:
         raise ValueError(f"unknown mesh name: {mesh_name}")
 
@@ -1619,8 +1593,7 @@ def test_mesh_multiple_groups(actx_factory, ambient_dim, visualize=False):
 
     order = 4
 
-    from meshmode.mesh.generation import generate_regular_rect_mesh
-    mesh = generate_regular_rect_mesh(
+    mesh = mgen.generate_regular_rect_mesh(
             a=(-0.5,)*ambient_dim, b=(0.5,)*ambient_dim,
             n=(8,)*ambient_dim, order=order)
     assert len(mesh.groups) == 1
@@ -1698,6 +1671,43 @@ def test_mesh_multiple_groups(actx_factory, ambient_dim, visualize=False):
 
     x = thaw(actx, discr.nodes())
     discr.num_reference_derivative(ref_axes, x[0])
+
+
+@pytest.mark.parametrize("ambient_dim", [2, 3])
+def test_mesh_with_interior_unit_nodes(ambient_dim):
+    # NOTE: smaller orders or coarser meshes make the cases fail the
+    # node_vertex_consistency test; the default warp_and_blend_nodes have
+    # nodes at the vertices, so they pass for much smaller tolerances
+
+    order = 8
+    nelements = 32
+    n_minor = 2 * nelements
+    uniform_refinement_rounds = 4
+
+    import modepy as mp
+    if ambient_dim == 2:
+        unit_nodes = mp.LegendreGaussQuadrature(
+                order, force_dim_axis=True).nodes
+
+        mesh = mgen.make_curve_mesh(
+                partial(mgen.ellipse, 2.0),
+                np.linspace(0.0, 1.0, nelements + 1), order=order,
+                unit_nodes=unit_nodes)
+    elif ambient_dim == 3:
+        unit_nodes = mp.VioreanuRokhlinSimplexQuadrature(order, 2).nodes
+
+        mesh = mgen.generate_torus(4.0, 2.0,
+                n_major=2*n_minor, n_minor=n_minor,
+                order=order, unit_nodes=unit_nodes)
+
+        mesh = mgen.generate_icosphere(1.0,
+                uniform_refinement_rounds=uniform_refinement_rounds,
+                order=order, unit_nodes=unit_nodes)
+    else:
+        raise ValueError(f"unsupported dimension: '{ambient_dim}'")
+
+    assert mesh.facial_adjacency_groups
+    assert mesh.nodal_adjacency
 
 
 if __name__ == "__main__":

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -1674,7 +1674,9 @@ def test_mesh_multiple_groups(actx_factory, ambient_dim, visualize=False):
 
 
 @pytest.mark.parametrize("ambient_dim", [2, 3])
-def test_mesh_with_interior_unit_nodes(ambient_dim):
+def test_mesh_with_interior_unit_nodes(actx_factory, ambient_dim):
+    actx = actx_factory()
+
     # NOTE: smaller orders or coarser meshes make the cases fail the
     # node_vertex_consistency test; the default warp_and_blend_nodes have
     # nodes at the vertices, so they pass for much smaller tolerances
@@ -1708,6 +1710,17 @@ def test_mesh_with_interior_unit_nodes(ambient_dim):
 
     assert mesh.facial_adjacency_groups
     assert mesh.nodal_adjacency
+
+    from meshmode.discretization import Discretization
+    from meshmode.discretization.poly_element import QuadratureSimplexGroupFactory
+    discr = Discretization(actx, mesh,
+            QuadratureSimplexGroupFactory(order))
+
+    from meshmode.discretization.connection import make_face_restriction
+    conn = make_face_restriction(actx, discr,
+            group_factory=QuadratureSimplexGroupFactory(order),
+            boundary_tag=FACE_RESTR_ALL)
+    assert conn
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Included changes:

* Adds a test that uses interior quadrature nodes in the `Mesh`.
* Adds a `unit_nodes` argument to `generate_icosphere` and `generator_torus`.

It seems to be working as expected. The only hiccup is that it requires a lot more elements to actually pass `_test_node_vertex_consistency`.