### PR TITLE
Slightly adjust test tolerance

### DIFF
--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -505,7 +505,7 @@ def test_boundary_interpolation(actx_factory, group_factory, boundary_tag,
     print(eoc_rec)
     assert (
             eoc_rec.order_estimate() >= order-order_slack
-            or eoc_rec.max_error() < 3e-13)
+            or eoc_rec.max_error() < 3.6e-13)
 
 # }}}
 


### PR DESCRIPTION
Does exactly what it suggests :smile: 

This is based on some testing using the conda environment created via https://github.com/illinois-ceesd/emirge, and a conversation with @inducer.

It appears that using OpenBLAS from conda forge produces slightly different computed values in `test_meshmode.py`, causing test failures when using the conda environment for Mirgecom.