### PR TITLE
Add simple copy to Visualizer

### DIFF
--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -185,20 +185,11 @@ class _VisConnectivityGroup(Record):
 
 
 def _check_discr_same_connectivity(discr, other):
-    def _cmp(grp, ogrp):
-        # NOTE: include more things here if they become necessary
-        return (
-                type(grp) == type(ogrp)
-                and grp.order == ogrp.order
-                and grp.nelements == ogrp.nelements
-                and grp.nunit_dofs == ogrp.nunit_dofs
-                and np.array_equal(grp.unit_nodes, ogrp.unit_nodes)
-                )
-
     if len(discr.groups) != len(other.groups):
         return False
 
-    if not all(_cmp(sg, og) for sg, og in zip(discr.groups, other.groups)):
+    if not all(sg.discretization_key() == og.discretization_key()
+            for sg, og in zip(discr.groups, other.groups)):
         return False
 
     return True

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -188,7 +188,9 @@ def _check_discr_same_connectivity(discr, other):
     if len(discr.groups) != len(other.groups):
         return False
 
-    if not all(sg.discretization_key() == og.discretization_key()
+    if not all(
+            sg.discretization_key() == og.discretization_key()
+            and sg.nelements == og.nelements
             for sg, og in zip(discr.groups, other.groups)):
         return False
 

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -462,6 +462,8 @@ class Visualizer:
     .. automethod:: write_vtk_file
     .. automethod:: write_parallel_vtk_file
     .. automethod:: write_xdmf_file
+
+    .. automethod:: copy_with_same_connectivity
     """
 
     def __init__(self, connection,
@@ -483,6 +485,20 @@ class Visualizer:
         self._cached_vtk_lagrange_connectivity = _vtk_lagrange_connectivity
 
     def copy_with_same_connectivity(self, actx, discr, skip_tests=False):
+        """Makes a copy of the visualizer for a
+        :class:`~meshmode.discretization.Discretization` with the same group
+        structure as the original discretization. This can be useful when the
+        geometry is mapped (e.g. using :func:`~meshmode.mesh.processing.affine_map`)
+        and the connectivity can be reused.
+
+        The *"same group structure"* here means that the two discretizations
+        should have the same group types, number of elements, degrees of
+        freedom, etc.
+
+        :param skip_tests: If *True*, no checks in the group structure of the
+            discretizations are performed.
+        """
+
         if not skip_tests:
             if not _check_discr_same_connectivity(discr, self.discr):
                 raise ValueError("'discr' does not have matching group structures")

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -276,6 +276,11 @@ def test_copy_visualizer(actx_factory, ambient_dim, visualize=True):
     assert translated_vis._cached_vtk_connectivity is not None
     assert translated_vis._cached_vtk_lagrange_connectivity is not None
 
+    assert translated_vis._vtk_connectivity \
+            is vis._vtk_connectivity
+    assert translated_vis._vtk_lagrange_connectivity \
+            is vis._vtk_lagrange_connectivity
+
     if not visualize:
         return
 


### PR DESCRIPTION
This tries to avoid rebuilding all the connectivity when doing IO for moving meshes (see #123).

I started doing a proper copy, but it seemed like too many things could get inconsistent. The current version just replaces the underlying discretization.