### PR TITLE
Move ElementGroup matrix methods to functions

### DIFF
--- a/examples/simple-dg.py
+++ b/examples/simple-dg.py
@@ -46,10 +46,11 @@ from meshmode.array_context import PyOpenCLArrayContext, make_loopy_program
 def parametrization_derivative(actx, discr):
     thawed_nodes = thaw(actx, discr.nodes())
 
+    from meshmode.discretization import num_reference_derivative
     result = np.zeros((discr.ambient_dim, discr.dim), dtype=object)
     for iambient in range(discr.ambient_dim):
         for idim in range(discr.dim):
-            result[iambient, idim] = discr.num_reference_derivative(
+            result[iambient, idim] = num_reference_derivative(discr,
                     (idim,), thawed_nodes[iambient])
 
     return result
@@ -191,8 +192,9 @@ class DGDiscretization:
     def grad(self, vec):
         ipder = self.inverse_parametrization_derivative()
 
+        from meshmode.discretization import num_reference_derivative
         dref = [
-                self.volume_discr.num_reference_derivative((idim,), vec)
+                num_reference_derivative(self.volume_discr, (idim,), vec)
                 for idim in range(self.volume_discr.dim)]
 
         return make_obj_array([

--- a/meshmode/discretization/__init__.py
+++ b/meshmode/discretization/__init__.py
@@ -604,13 +604,16 @@ def num_reference_derivative(
             name="diff")
 
     def get_mat(grp):
+        from meshmode.discretization.poly_element import diff_matrices
+        matrices = diff_matrices(grp)
+
         mat = None
         for ref_axis in ref_axes:
-            next_mat = grp.diff_matrices()[ref_axis]
+            next_mat = matrices[ref_axis]
             if mat is None:
                 mat = next_mat
             else:
-                mat = np.dot(next_mat, mat)
+                mat = next_mat @ mat
 
         return actx.from_numpy(mat)
 

--- a/meshmode/discretization/__init__.py
+++ b/meshmode/discretization/__init__.py
@@ -605,13 +605,13 @@ def num_reference_derivative(
 
     @keyed_memoize_in(actx,
             (num_reference_derivative, "num_reference_derivative_matrix"),
-            lambda grp: grp.discretization_key() + ref_axes)
-    def get_mat(grp):
+            lambda grp, gref_axes: grp.discretization_key() + gref_axes)
+    def get_mat(grp, gref_axes):
         from meshmode.discretization.poly_element import diff_matrices
         matrices = diff_matrices(grp)
 
         mat = None
-        for ref_axis in ref_axes:
+        for ref_axis in gref_axes:
             next_mat = matrices[ref_axis]
             if mat is None:
                 mat = next_mat
@@ -622,7 +622,7 @@ def num_reference_derivative(
 
     return _DOFArray(actx, tuple(
             actx.call_loopy(
-                prg(), diff_mat=get_mat(grp), vec=vec[grp.index]
+                prg(), diff_mat=get_mat(grp, ref_axes), vec=vec[grp.index]
                 )["result"]
             for grp in discr.groups))
 

--- a/meshmode/discretization/__init__.py
+++ b/meshmode/discretization/__init__.py
@@ -581,8 +581,8 @@ def num_reference_derivative(
     """
 
     if not all([
-        isinstance(grp, InterpolatoryElementGroupBase) for grp in discr.groups
-        ]):
+            isinstance(grp, InterpolatoryElementGroupBase) for grp in discr.groups
+            ]):
         raise NoninterpolatoryElementGroupError(
             "Element groups must be usuable for differentiation and interpolation.")
 

--- a/meshmode/discretization/__init__.py
+++ b/meshmode/discretization/__init__.py
@@ -596,7 +596,7 @@ def num_reference_derivative(
         raise ValueError("'ref_axes' exceeds discretization dimensions: "
                 f"got {ref_axes} for dimension {discr.dim}")
 
-    @memoize_in(actx, (Discretization, "reference_derivative_prg"))
+    @memoize_in(actx, (num_reference_derivative, "reference_derivative_prg"))
     def prg():
         return make_loopy_program(
             "{[iel,idof,j]: 0 <= iel < nelements and 0 <= idof, j < nunit_dofs}",

--- a/meshmode/discretization/connection/projection.py
+++ b/meshmode/discretization/connection/projection.py
@@ -105,11 +105,13 @@ class L2ProjectionInverseDiscretizationConnection(DiscretizationConnection):
         weights = {}
         jac = np.empty(self.to_discr.dim, dtype=object)
 
+        from meshmode.discretization.poly_element import diff_matrices
         for igrp, grp in enumerate(self.to_discr.groups):
+            matrices = diff_matrices(grp)
+
             for ibatch, batch in enumerate(self.conn.groups[igrp].batches):
                 for iaxis in range(grp.dim):
-                    mat = grp.diff_matrices()[iaxis]
-                    jac[iaxis] = mat.dot(batch.result_unit_nodes.T)
+                    jac[iaxis] = matrices[iaxis] @ batch.result_unit_nodes.T
 
                 weights[igrp, ibatch] = actx.freeze(actx.from_numpy(
                     det(jac) * grp.weights))

--- a/meshmode/discretization/poly_element.py
+++ b/meshmode/discretization/poly_element.py
@@ -99,7 +99,8 @@ Tensor product group factories
 @memoize_on_first_arg
 def mass_matrix(grp: InterpolatoryElementGroupBase) -> np.ndarray:
     if not isinstance(grp, InterpolatoryElementGroupBase):
-        raise TypeError(f"cannot construct mass matrix on '{type(grp).__name__}'")
+        raise NoninterpolatoryElementGroupError(
+                f"cannot construct mass matrix on '{type(grp).__name__}'")
 
     assert grp.is_orthonormal_basis()
     return mp.mass_matrix(
@@ -110,7 +111,8 @@ def mass_matrix(grp: InterpolatoryElementGroupBase) -> np.ndarray:
 @memoize_on_first_arg
 def inverse_mass_matrix(grp: InterpolatoryElementGroupBase) -> np.ndarray:
     if not isinstance(grp, InterpolatoryElementGroupBase):
-        raise TypeError(f"cannot construct mass matrix on '{type(grp).__name__}'")
+        raise NoninterpolatoryElementGroupError(
+                f"cannot construct mass matrix on '{type(grp).__name__}'")
 
     return mp.inverse_mass_matrix(
             grp.basis_obj().functions,
@@ -120,7 +122,8 @@ def inverse_mass_matrix(grp: InterpolatoryElementGroupBase) -> np.ndarray:
 @memoize_on_first_arg
 def diff_matrices(grp: InterpolatoryElementGroupBase) -> Tuple[np.ndarray]:
     if not isinstance(grp, InterpolatoryElementGroupBase):
-        raise TypeError(f"cannot construct diff matrices on '{type(grp).__name__}'")
+        raise NoninterpolatoryElementGroupError(
+                f"cannot construct diff matrices on '{type(grp).__name__}'")
 
     basis_fcts = grp.basis_obj().functions
     grad_basis_fcts = grp.basis_obj().gradients

--- a/meshmode/discretization/poly_element.py
+++ b/meshmode/discretization/poly_element.py
@@ -109,17 +109,6 @@ def mass_matrix(grp: InterpolatoryElementGroupBase) -> np.ndarray:
 
 
 @memoize_on_first_arg
-def inverse_mass_matrix(grp: InterpolatoryElementGroupBase) -> np.ndarray:
-    if not isinstance(grp, InterpolatoryElementGroupBase):
-        raise NoninterpolatoryElementGroupError(
-                f"cannot construct mass matrix on '{type(grp).__name__}'")
-
-    return mp.inverse_mass_matrix(
-            grp.basis_obj().functions,
-            grp.unit_nodes)
-
-
-@memoize_on_first_arg
 def diff_matrices(grp: InterpolatoryElementGroupBase) -> Tuple[np.ndarray]:
     if not isinstance(grp, InterpolatoryElementGroupBase):
         raise NoninterpolatoryElementGroupError(

--- a/meshmode/discretization/poly_element.py
+++ b/meshmode/discretization/poly_element.py
@@ -141,11 +141,7 @@ def diff_matrices(grp: InterpolatoryElementGroupBase) -> Tuple[np.ndarray, ...]:
 
 
 @memoize_on_first_arg
-def from_mesh_interp_matrix(grp: InterpolatoryElementGroupBase) -> np.ndarray:
-    if not isinstance(grp, InterpolatoryElementGroupBase):
-        raise TypeError(
-                f"cannot construct resampling matrix on '{type(grp).__name__}'")
-
+def from_mesh_interp_matrix(grp: NodalElementGroupBase) -> np.ndarray:
     meg = grp.mesh_el_group
     meg_space = type(grp.space)(meg.dim, meg.order)
 
@@ -156,11 +152,7 @@ def from_mesh_interp_matrix(grp: InterpolatoryElementGroupBase) -> np.ndarray:
 
 
 @memoize_on_first_arg
-def to_mesh_interp_matrix(grp: InterpolatoryElementGroupBase) -> np.ndarray:
-    if not isinstance(grp, InterpolatoryElementGroupBase):
-        raise TypeError(
-                f"cannot construct resampling matrix on '{type(grp).__name__}'")
-
+def to_mesh_interp_matrix(grp: NodalElementGroupBase) -> np.ndarray:
     return mp.resampling_matrix(
             grp.basis_obj().functions,
             grp.mesh_el_group.unit_nodes,

--- a/meshmode/discretization/poly_element.py
+++ b/meshmode/discretization/poly_element.py
@@ -118,7 +118,7 @@ def inverse_mass_matrix(grp: InterpolatoryElementGroupBase) -> np.ndarray:
 
 
 @memoize(key=lambda grp: grp.discretization_key())
-def diff_matrices(grp: InterpolatoryElementGroupBase) -> Tuple[np.ndarray, ...]:
+def diff_matrices(grp: InterpolatoryElementGroupBase) -> Tuple[np.ndarray]:
     if not isinstance(grp, InterpolatoryElementGroupBase):
         raise TypeError(f"cannot construct diff matrices on '{type(grp).__name__}'")
 

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -1705,8 +1705,9 @@ def test_mesh_multiple_groups(actx_factory, ambient_dim, visualize=False):
     import pytools
     ref_axes = pytools.flatten([[i] for i in range(ambient_dim)])
 
+    from meshmode.discretization import num_reference_derivative
     x = thaw(actx, discr.nodes())
-    discr.num_reference_derivative(ref_axes, x[0])
+    num_reference_derivative(discr, ref_axes, x[0])
 
 
 @pytest.mark.parametrize("ambient_dim", [2, 3])

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -285,9 +285,9 @@ def test_copy_visualizer(actx_factory, ambient_dim, visualize=True):
         return
 
     vis.write_vtk_file(
-            f"visualizer_copy_{ambient_dim}d_orig.vtu", [])
+            f"visualizer_copy_{ambient_dim}d_orig.vtu", [], overwrite=True)
     translated_vis.write_vtk_file(
-            f"visualizer_copy_{ambient_dim}d_translated.vtu", [])
+            f"visualizer_copy_{ambient_dim}d_translated.vtu", [], overwrite=True)
 
 # }}}
 


### PR DESCRIPTION
This does a couple of things
* Makes `num_reference_derivative` a function (part of #141)
* Makes `mass_matrix`, `diff_matrices` and `from_mesh_interp_matrix` functions (part of #141)
* ~~Adds the results to a global cache (helps with #123)~~

Fixes #141