### PR TITLE
Fix bug in MPIBoundaryCommSetupHelper

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -78,6 +78,7 @@ intersphinx_mapping = {
     "https://documen.tician.de/modepy": None,
     "https://documen.tician.de/loopy": None,
     "https://documen.tician.de/gmsh_interop": None,
+    "https://documen.tician.de/pymetis": None,
     "https://firedrakeproject.org/": None,
     "https://tisaac.gitlab.io/recursivenodes/": None,
     "https://fenics.readthedocs.io/projects/fiat/en/latest/": None,

--- a/doc/distributed.rst
+++ b/doc/distributed.rst
@@ -1,0 +1,4 @@
+Distributed memory
+==================
+
+.. automodule:: meshmode.distributed

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,6 +10,7 @@ Contents:
    array
    discretization
    connection
+   distributed
    interop
    misc
    🚀 Github <https://github.com/inducer/meshmode>

--- a/meshmode/distributed.py
+++ b/meshmode/distributed.py
@@ -189,19 +189,18 @@ class MPIBoundaryCommSetupHelper:
         self._internal_mpi_comm = self.mpi_comm.Dup()
 
         logger.info("bdry comm rank %d comm begin", self.i_local_part)
-        self.recv_reqs = []
-        for i_remote_part in self.connected_parts:
-            self.recv_reqs.append(
-                self._internal_mpi_comm.irecv(source=i_remote_part))
 
-        self.send_reqs = []
-        for i_remote_part in self.connected_parts:
-            self.send_reqs.append(
-                self._internal_mpi_comm.isend((
-                    self.local_bdry_conns[i_remote_part].to_discr.mesh,
-                    make_remote_group_infos(
-                        self.array_context, self.local_bdry_conns[i_remote_part])),
-                    dest=i_remote_part))
+        self.recv_reqs = [
+            self._internal_mpi_comm.irecv(source=i_remote_part)
+            for i_remote_part in self.connected_parts]
+
+        self.send_reqs = [
+            self._internal_mpi_comm.isend((
+                self.local_bdry_conns[i_remote_part].to_discr.mesh,
+                make_remote_group_infos(
+                    self.array_context, self.local_bdry_conns[i_remote_part])),
+                dest=i_remote_part)
+            for i_remote_part in self.connected_parts]
 
         return self
 

--- a/meshmode/distributed.py
+++ b/meshmode/distributed.py
@@ -52,11 +52,11 @@ class MPIMeshDistributor:
     """
     .. automethod:: is_mananger_rank
     .. automethod:: send_mesh_parts
-    .. automethod:: recv_mesh_part
+    .. automethod:: receive_mesh_part
     """
     def __init__(self, mpi_comm, manager_rank=0):
         """
-        :arg mpi_comm: A :class:`MPI.Intracomm`
+        :arg mpi_comm: An ``MPI.Intracomm``
         """
         self.mpi_comm = mpi_comm
         self.manager_rank = manager_rank
@@ -66,7 +66,7 @@ class MPIMeshDistributor:
 
     def send_mesh_parts(self, mesh, part_per_element, num_parts):
         """
-        :arg mesh: A :class:`Mesh` to distribute to other ranks.
+        :arg mesh: A :class:`~meshmode.mesh.Mesh` to distribute to other ranks.
         :arg part_per_element: A :class:`numpy.ndarray` containing one
             integer per element of *mesh* indicating which part of the
             partitioned mesh the element is to become a part of.
@@ -163,11 +163,12 @@ class MPIBoundaryCommSetupHelper:
     """
     def __init__(self, mpi_comm, actx, local_bdry_conns, bdry_grp_factory):
         """
-        :arg mpi_comm: A :class:`MPI.Intracomm`
+        :arg mpi_comm: An ``MPI.Intracomm``
         :arg actx: An array context
         :arg local_bdry_conns: A :class:`dict` mapping remote partition to
             `local_bdry_conn`, where `local_bdry_conn` is a
-            :class:`DirectDiscretizationConnection` that performs data exchange from
+            :class:`~meshmode.discretization.connection.DirectDiscretizationConnection`
+            that performs data exchange from
             the volume to the faces adjacent to partition `i_remote_part`.
         :arg bdry_grp_factory: Group factory to use when creating the remote-to-local
             boundary connections
@@ -208,9 +209,11 @@ class MPIBoundaryCommSetupHelper:
         """
         Returns a :class:`dict` mapping a subset of remote partitions to
         remote-to-local boundary connections, where a remote-to-local boundary
-        connection is a :class:`DirectDiscretizationConnection` that performs data
-        exchange across faces from partition `i_remote_part` to the local mesh. When
-        an empty dictionary is returned, setup is complete.
+        connection is a
+        :class:`~meshmode.discretization.connection.DirectDiscretizationConnection`
+        that performs data exchange across faces from partition `i_remote_part`
+        to the local mesh. When an empty dictionary is returned, setup is
+        complete.
         """
         from mpi4py import MPI
 

--- a/meshmode/distributed.py
+++ b/meshmode/distributed.py
@@ -166,9 +166,9 @@ class MPIBoundaryCommSetupHelper:
         """
         :arg mpi_comm: A :class:`MPI.Intracomm`
         :arg actx: An array context
-        :arg connected_parts: A `set` of remote partitions that are connected to the
-            local partition
-        :arg local_bdry_conns: A `dict` mapping remote partition to
+        :arg connected_parts: A :class:`set` of remote partitions that are connected
+            to the local partition
+        :arg local_bdry_conns: A :class:`dict` mapping remote partition to
             `local_bdry_conn`, where `local_bdry_conn` is a
             :class:`DirectDiscretizationConnection` that performs data exchange from
             the volume to the faces adjacent to partition `i_remote_part`.
@@ -211,10 +211,10 @@ class MPIBoundaryCommSetupHelper:
 
     def complete_some(self):
         """
-        Returns a `dict` mapping a subset of remote partitions to remote-to-local
-        boundary connections, where a remote-to-local boundary connection is a
-        :class:`DirectDiscretizationConnection` that performs data exchange across
-        faces from partition `i_remote_part` to the local mesh.
+        Returns a :class:`dict` mapping a subset of remote partitions to
+        remote-to-local boundary connections, where a remote-to-local boundary
+        connection is a :class:`DirectDiscretizationConnection` that performs data
+        exchange across faces from partition `i_remote_part` to the local mesh.
         """
         from mpi4py import MPI
 

--- a/meshmode/distributed.py
+++ b/meshmode/distributed.py
@@ -212,7 +212,8 @@ class MPIBoundaryCommSetupHelper:
         Returns a :class:`dict` mapping a subset of remote partitions to
         remote-to-local boundary connections, where a remote-to-local boundary
         connection is a :class:`DirectDiscretizationConnection` that performs data
-        exchange across faces from partition `i_remote_part` to the local mesh.
+        exchange across faces from partition `i_remote_part` to the local mesh. When
+        an empty dictionary is returned, setup is complete.
         """
         from mpi4py import MPI
 

--- a/meshmode/distributed.py
+++ b/meshmode/distributed.py
@@ -182,17 +182,17 @@ class MPIBoundaryCommSetupHelper:
                 dest=self.i_remote_part,
                 tag=TAG_SEND_BOUNDARY)
 
-    def post_sends(self):
+    def post_send(self):
         logger.info("bdry comm rank %d send begin", self.i_local_part)
         self.send_req = self._post_send_boundary_data()
 
-    def is_setup_ready(self):
+    def is_recv_ready(self):
         """
         Returns True if the rank boundary data is ready to be received.
         """
         return self.mpi_comm.Iprobe(source=self.i_remote_part, tag=TAG_SEND_BOUNDARY)
 
-    def complete_setup(self):
+    def recv(self):
         """
         Returns the tuple ``remote_to_local_bdry_conn``
         where `remote_to_local_bdry_conn` is a
@@ -219,8 +219,10 @@ class MPIBoundaryCommSetupHelper:
                     group_factory=self.bdry_grp_factory),
                 remote_group_infos=remote_group_infos)
 
-        self.send_req.wait()
         return remote_to_local_bdry_conn
+
+    def complete_send(self):
+        self.send_req.wait()
 
 # }}}
 

--- a/meshmode/distributed.py
+++ b/meshmode/distributed.py
@@ -248,7 +248,8 @@ class MPIBoundaryCommSetupHelper:
                         group_factory=self.bdry_grp_factory),
                     remote_group_infos=remote_group_infos)
 
-        if not remote_to_local_bdry_conns:
+        all_recvs_completed = not remote_to_local_bdry_conns
+        if all_recvs_completed:
             MPI.Request.waitall(self.send_reqs)
 
         return remote_to_local_bdry_conns

--- a/meshmode/distributed.py
+++ b/meshmode/distributed.py
@@ -188,13 +188,12 @@ class MPIBoundaryCommSetupHelper:
     def __enter__(self):
         self._internal_mpi_comm = self.mpi_comm.Dup()
 
-        logger.info("bdry comm rank %d recv begin", self.i_local_part)
+        logger.info("bdry comm rank %d comm begin", self.i_local_part)
         self.recv_reqs = []
         for i_remote_part in self.connected_parts:
             self.recv_reqs.append(
                 self._internal_mpi_comm.irecv(source=i_remote_part))
 
-        logger.info("bdry comm rank %d send begin", self.i_local_part)
         self.send_reqs = []
         for i_remote_part in self.connected_parts:
             self.send_reqs.append(
@@ -251,6 +250,7 @@ class MPIBoundaryCommSetupHelper:
         all_recvs_completed = not remote_to_local_bdry_conns
         if all_recvs_completed:
             MPI.Request.waitall(self.send_reqs)
+            logger.info("bdry comm rank %d comm end", self.i_local_part)
 
         return remote_to_local_bdry_conns
 

--- a/meshmode/distributed.py
+++ b/meshmode/distributed.py
@@ -161,13 +161,10 @@ class MPIBoundaryCommSetupHelper:
     .. automethod:: __exit__
     .. automethod:: complete_some
     """
-    def __init__(self, mpi_comm, actx, connected_parts, local_bdry_conns,
-            bdry_grp_factory):
+    def __init__(self, mpi_comm, actx, local_bdry_conns, bdry_grp_factory):
         """
         :arg mpi_comm: A :class:`MPI.Intracomm`
         :arg actx: An array context
-        :arg connected_parts: A :class:`set` of remote partitions that are connected
-            to the local partition
         :arg local_bdry_conns: A :class:`dict` mapping remote partition to
             `local_bdry_conn`, where `local_bdry_conn` is a
             :class:`DirectDiscretizationConnection` that performs data exchange from
@@ -178,7 +175,7 @@ class MPIBoundaryCommSetupHelper:
         self.mpi_comm = mpi_comm
         self.array_context = actx
         self.i_local_part = mpi_comm.Get_rank()
-        self.connected_parts = list(connected_parts)
+        self.connected_parts = list(local_bdry_conns.keys())
         self.local_bdry_conns = local_bdry_conns
         self.bdry_grp_factory = bdry_grp_factory
         self._internal_mpi_comm = None

--- a/test/test_partition.py
+++ b/test/test_partition.py
@@ -365,8 +365,8 @@ def _test_mpi_boundary_swap(dim, order, num_groups):
                 actx, vol_discr, group_factory, BTAG_PARTITION(i_remote_part))
 
     remote_to_local_bdry_conns = {}
-    with MPIBoundaryCommSetupHelper(mpi_comm, actx, connected_parts,
-            local_bdry_conns, bdry_grp_factory=group_factory) as bdry_setup_helper:
+    with MPIBoundaryCommSetupHelper(mpi_comm, actx, local_bdry_conns,
+            bdry_grp_factory=group_factory) as bdry_setup_helper:
         from meshmode.discretization.connection import check_connection
         while True:
             conns = bdry_setup_helper.complete_some()

--- a/test/test_partition.py
+++ b/test/test_partition.py
@@ -368,7 +368,10 @@ def _test_mpi_boundary_swap(dim, order, num_groups):
     with MPIBoundaryCommSetupHelper(mpi_comm, actx, connected_parts,
             local_bdry_conns, bdry_grp_factory=group_factory) as bdry_setup_helper:
         from meshmode.discretization.connection import check_connection
-        while conns := bdry_setup_helper.complete_some():
+        while True:
+            conns = bdry_setup_helper.complete_some()
+            if not conns:
+                break
             for i_remote_part, conn in conns.items():
                 check_connection(actx, conn)
                 remote_to_local_bdry_conns[i_remote_part] = conn


### PR DESCRIPTION
I found the source of my CI hangs in #133. `MPIBoundaryCommSetupHelper` was doing something not so safe: it was waiting on its send request immediately after receiving, instead of waiting until all the receives are done. This PR tweaks its API to allow waiting on the sends separately.

I think grudge managed to avoid bumping into this because it completes the receives in order (unlike the partition tests here).

:warning:  Should land at the same time as https://github.com/inducer/grudge/pull/63