### PR TITLE
Flatten and unflatten by reshaping when possible

### DIFF
--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -499,7 +499,7 @@ def flatten(ary: Union[DOFArray, np.ndarray]) -> Any:
     # NOTE: arrays with one group are common enough and don't require any
     # concatenation to "flatten", but can just be reshaped
     if len(ary) == 1:
-        ary0 = list(ary)[0]
+        ary0, = ary
         if ary0.flags.c_contiguous:
             return ary0.reshape(-1, order="C")
         elif ary0.flags.f_contiguous:

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -499,7 +499,14 @@ def flatten(ary: Union[DOFArray, np.ndarray]) -> Any:
     # NOTE: arrays with one group are common enough and don't require any
     # concatenation to "flatten", but can just be reshaped
     if len(ary) == 1:
-        return list(ary)[0].reshape(-1)
+        ary0 = list(ary)[0]
+        if ary0.flags.c_contiguous:
+            return ary0.reshape(-1, order="C")
+        elif ary0.flags.f_contiguous:
+            return ary0.reshape(-1, order="F")
+        else:
+            # NOTE: array has unsupported strides, so we need to do a copy
+            pass
 
     group_sizes = [grp_ary.shape[0] * grp_ary.shape[1] for grp_ary in ary]
     group_starts = np.cumsum([0] + group_sizes)


### PR DESCRIPTION
Is this sort of what you hand in mind in https://github.com/inducer/pytential/pull/71#discussion_r609231956? 
It seems to do the trick, i.e. `flatten` and `unflatten` don't show up anywhere near the top of any profiling (for a single group mesh at least).