### PR TITLE
Use `ZeroDimensionalQuadrature` for 0-dim reference cells

### DIFF
--- a/meshmode/discretization/poly_element.py
+++ b/meshmode/discretization/poly_element.py
@@ -236,7 +236,7 @@ class InterpolatoryQuadratureSimplexElementGroup(PolynomialSimplexElementGroupBa
     def _quadrature_rule(self):
         dims = self.mesh_el_group.dim
         if dims == 0:
-            return mp.Quadrature(np.empty((0, 1)), np.ones((1,)))
+            return mp.ZeroDimensionalQuadrature()
         elif dims == 1:
             return mp.LegendreGaussQuadrature(self.order)
         else:
@@ -272,7 +272,7 @@ class QuadratureSimplexElementGroup(SimplexElementGroupBase):
     def _quadrature_rule(self):
         dims = self.mesh_el_group.dim
         if dims == 0:
-            return mp.Quadrature(np.empty((0, 1)), np.ones((1,)))
+            return mp.ZeroDimensionalQuadrature()
         elif dims == 1:
             return mp.LegendreGaussQuadrature(self.order, force_dim_axis=True)
         else:


### PR DESCRIPTION
Thanks to @alexfikl for fixing this in modepy! This just carries over that change into meshmode.