### PR TITLE
Make `quadrature_rule` a public-facing method

### DIFF
--- a/meshmode/discretization/__init__.py
+++ b/meshmode/discretization/__init__.py
@@ -194,11 +194,23 @@ class NodalElementGroupBase(ElementGroupBase):
         """
         return self.unit_nodes.shape[-1]
 
-    @abstractproperty
+    @property
+    @memoize_method
     def unit_nodes(self):
         """Returns a :class:`numpy.ndarray` of shape ``(dim, nunit_dofs)``
         of reference coordinates of interpolation nodes.
+
+        Note: this method dispatches to the nodes of the underlying
+        quadrature rule. This means, for interpolatory element groups,
+        interpolation nodes are collocated with quadrature nodes.
         """
+        result = self.quadrature_rule().nodes
+        if len(result.shape) == 1:
+            result = np.array([result])
+
+        dim2, _ = result.shape
+        assert dim2 == self.mesh_el_group.dim
+        return result
 
     @abstractmethod
     def quadrature_rule(self):

--- a/meshmode/discretization/__init__.py
+++ b/meshmode/discretization/__init__.py
@@ -177,14 +177,14 @@ class NodalElementGroupBase(ElementGroupBase):
     equipped with nodes. Nodes are specific locations defined on the
     reference element (:attr:`~ElementGroupBase.shape`)
     defining a degree of freedom by point evaluation at that location.
-    Such element groups can have an associated quadrature rule to perform
+    Such element groups have an associated quadrature rule to perform
     numerical integration, but are not necessarily usable (unisolvent)
     for interpolation.
 
     Inherits from :class:`ElementGroupBase`.
 
     .. autoattribute:: unit_nodes
-    .. autoattribute:: weights
+    .. automethod:: quadrature_rule
     """
 
     @property
@@ -200,12 +200,23 @@ class NodalElementGroupBase(ElementGroupBase):
         of reference coordinates of interpolation nodes.
         """
 
-    @abstractproperty
+    @abstractmethod
+    def quadrature_rule(self):
+        """Returns a :class:`modepy.Quadrature` object for the
+        element group.
+        """
+
+    @property
     def weights(self):
         """Returns a :class:`numpy.ndarray` of shape ``(nunit_dofs,)``
         containing quadrature weights applicable on the reference
         element.
         """
+        warn("`grp.weights` will be dropped in version 2022.x "
+             "To access the quadrature weights, use "
+             "`grp.quadrature_rule().weights` instead.",
+             DeprecationWarning, stacklevel=2)
+        return self.quadrature_rule().weights
 
 # }}}
 

--- a/meshmode/discretization/__init__.py
+++ b/meshmode/discretization/__init__.py
@@ -224,8 +224,8 @@ class NodalElementGroupBase(ElementGroupBase):
         containing quadrature weights applicable on the reference
         element.
         """
-        warn("`grp.weights` will be dropped in version 2022.x "
-             "To access the quadrature weights, use "
+        warn("`grp.weights` is deprecated and will be dropped "
+             "in version 2022.x. To access the quadrature weights, use "
              "`grp.quadrature_rule().weights` instead.",
              DeprecationWarning, stacklevel=2)
         return self.quadrature_rule().weights
@@ -254,24 +254,24 @@ class ElementGroupWithBasis(ElementGroupBase):
 
     @memoize_method
     def mode_ids(self):
-        warn("`grp.mode_ids()` will be dropped in version 2022.x "
-             "To access the basis function mode ids, use "
+        warn("`grp.mode_ids()` is deprecated and will be dropped "
+             "in version 2022.x. To access the basis function mode ids, use "
              "`grp.basis_obj().mode_ids` instead.",
              DeprecationWarning, stacklevel=2)
         return self.basis_obj().mode_ids
 
     @memoize_method
     def basis(self):
-        warn("`grp.basis()` will be dropped in version 2022.x "
-             "To access the basis functions, use "
+        warn("`grp.basis()` is deprecated and will be dropped "
+             "in version 2022.x. To access the basis functions, use "
              "`grp.basis_obj().functions` instead.",
              DeprecationWarning, stacklevel=2)
         return self.basis_obj().functions
 
     @memoize_method
     def grad_basis(self):
-        warn("`grp.grad_basis()` will be dropped in version 2022.x "
-             "To access the basis function gradients, use "
+        warn("`grp.grad_basis()` is deprecated and will be dropped "
+             "in version 2022.x. To access the basis function gradients, use "
              "`grp.basis_obj().gradients` instead.",
              DeprecationWarning, stacklevel=2)
         return self.basis_obj().gradients
@@ -290,8 +290,9 @@ class ElementGroupWithBasis(ElementGroupBase):
             return False
 
     def is_orthogonal_basis(self):
-        warn("`is_orthogonal_basis` will be dropped in version 2022.x "
-             "since orthonormality is the more operationally important case. "
+        warn("`is_orthogonal_basis` is deprecated and will be dropped "
+             "in version 2022.x since orthonormality is the more "
+             "operationally important case. "
              "Use `is_orthonormal_basis` instead.",
              DeprecationWarning, stacklevel=2)
         return self.is_orthonormal_basis()

--- a/meshmode/discretization/connection/modal.py
+++ b/meshmode/discretization/connection/modal.py
@@ -225,10 +225,8 @@ class NodalToModalDiscretizationConnection(DiscretizationConnection):
             # to compute the modal coefficients.
             if isinstance(grp, QuadratureSimplexElementGroup):
 
-                if (
-                    grp._quadrature_rule().exact_to < 2*mgrp.order
-                    and not self._allow_approximate_quad
-                ):
+                if (grp.quadrature_rule().exact_to < 2*mgrp.order
+                        and not self._allow_approximate_quad):
                     raise ValueError("Quadrature rule is not exact, please "
                                      "set `allow_approximate_quad=True`")
 

--- a/meshmode/discretization/poly_element.py
+++ b/meshmode/discretization/poly_element.py
@@ -267,11 +267,18 @@ class _MassMatrixQuadratureElementGroup(PolynomialSimplexElementGroupBase):
     @memoize_method
     def quadrature_rule(self):
         basis_fcts = self.basis_obj().functions
-        nodes = self._nodes
+        nodes = self.interp_nodes
         mass_matrix = mp.mass_matrix(basis_fcts, nodes)
         weights = np.dot(mass_matrix,
                          np.ones(len(basis_fcts)))
         return mp.Quadrature(nodes, weights, exact_to=self.order)
+
+    @property
+    def interp_nodes(self):
+        raise NotImplementedError(
+            "Subclasses of `_MassMatrixQuadratureElementGroup` must "
+            "provide interpolation nodes to be used for quadrature."
+        )
 
 
 class PolynomialWarpAndBlendElementGroup(_MassMatrixQuadratureElementGroup):
@@ -284,7 +291,7 @@ class PolynomialWarpAndBlendElementGroup(_MassMatrixQuadratureElementGroup):
     """
     @property
     @memoize_method
-    def _nodes(self):
+    def interp_nodes(self):
         dim = self.mesh_el_group.dim
         if self.order == 0:
             result = mp.warp_and_blend_nodes(dim, 1)
@@ -321,7 +328,7 @@ class PolynomialRecursiveNodesElementGroup(_MassMatrixQuadratureElementGroup):
 
     @property
     @memoize_method
-    def _nodes(self):
+    def interp_nodes(self):
         dim = self.mesh_el_group.dim
 
         from recursivenodes import recursive_nodes
@@ -346,7 +353,7 @@ class PolynomialEquidistantSimplexElementGroup(_MassMatrixQuadratureElementGroup
     """
     @property
     @memoize_method
-    def _nodes(self):
+    def interp_nodes(self):
         dim = self.mesh_el_group.dim
         result = mp.equidistant_nodes(dim, self.order)
 
@@ -365,7 +372,7 @@ class PolynomialGivenNodesElementGroup(_MassMatrixQuadratureElementGroup):
         self._unit_nodes = unit_nodes
 
     @property
-    def _nodes(self):
+    def interp_nodes(self):
         dim2, nunit_nodes = self._unit_nodes.shape
 
         if dim2 != self.mesh_el_group.dim:

--- a/test/test_modal.py
+++ b/test/test_modal.py
@@ -150,7 +150,7 @@ def test_modal_coefficients_by_projection(actx_factory, quad_group_factory):
     shape = mp.Simplex(grp.dim)
     space = mp.space_for_shape(shape, order=m_order)
     basis = mp.orthonormal_basis_for_space(space, shape)
-    quad = grp._quadrature_rule()
+    quad = grp.quadrature_rule()
 
     nodal_f_data = actx.to_numpy(nodal_f[0])
     vdm = mp.vandermonde(basis.functions, quad.nodes)


### PR DESCRIPTION
Retires `weights` and instead exposes a `modepy.Quadrature` object associated with relevant element groups