### PR TITLE
Add a generic ArrayContainer

### DIFF
--- a/examples/simple-dg.py
+++ b/examples/simple-dg.py
@@ -30,16 +30,12 @@ from pytools import memoize_method, memoize_in
 from pytools.obj_array import (
         flat_obj_array, make_obj_array)
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
-from meshmode.dof_array import (
-        DOFArray,
-        # deserialize_container_class, serialize_container,
-        map_dof_array_container
-        )
+from meshmode.dof_array import DOFArray, rec_map_dof_array_container
 from meshmode.array_context import (
         freeze, thaw,
         PyOpenCLArrayContext, make_loopy_program,
         ArrayContainer, NumpyObjectArray,
-        array_container_vectorize,
+        map_array_container,
         DataclassArrayContainerWithArithmetic,
         )
 
@@ -240,7 +236,7 @@ class DGDiscretization:
 
     def inverse_mass(self, vec):
         if not isinstance(vec, DOFArray):
-            return map_dof_array_container(self.inverse_mass, vec)
+            return rec_map_dof_array_container(self.inverse_mass, vec)
 
         @memoize_in(self, "elwise_linear_knl")
         def knl():
@@ -293,7 +289,7 @@ class DGDiscretization:
 
     def face_mass(self, vec):
         if not isinstance(vec, DOFArray):
-            return map_dof_array_container(self.face_mass, vec)
+            return rec_map_dof_array_container(self.face_mass, vec)
 
         @memoize_in(self, "face_mass_knl")
         def knl():
@@ -342,7 +338,7 @@ class TracePair(DataclassArrayContainerWithArithmetic):
     exterior: ArrayContainer
 
     def __getattr__(self, name):
-        return array_container_vectorize(
+        return map_array_container(
                 lambda ary: getattr(ary, name),
                 self)
 

--- a/examples/simple-dg.py
+++ b/examples/simple-dg.py
@@ -21,7 +21,6 @@ THE SOFTWARE.
 """
 
 from dataclasses import dataclass
-
 import numpy as np
 import numpy.linalg as la  # noqa
 
@@ -36,9 +35,10 @@ from meshmode.dof_array import DOFArray
 from meshmode.array_context import (
         freeze, thaw,
         PyOpenCLArrayContext, make_loopy_program,
-        ArrayContainer, NumpyObjectArray,
+        ArrayContainer,
         map_array_container,
-        DataclassArrayContainerWithArithmetic,
+        ArrayContainerWithArithmetic,
+        dataclass_array_container,
         )
 
 import logging
@@ -336,8 +336,9 @@ class DGDiscretization:
 
 # {{{ trace pair
 
+@dataclass_array_container
 @dataclass(frozen=True)
-class TracePair(DataclassArrayContainerWithArithmetic):
+class TracePair(ArrayContainerWithArithmetic):
     where: str
     interior: ArrayContainer
     exterior: ArrayContainer
@@ -445,10 +446,11 @@ def bump(actx, discr, t=0):
             / source_width**2))
 
 
+@dataclass_array_container
 @dataclass(frozen=True)
-class WaveState(DataclassArrayContainerWithArithmetic):
+class WaveState(ArrayContainerWithArithmetic):
     u: DOFArray
-    v: NumpyObjectArray
+    v: np.ndarray  # [object]
 
     def __post_init__(self):
         assert isinstance(self.v, np.ndarray) and self.v.dtype.char == "O"

--- a/examples/simple-dg.py
+++ b/examples/simple-dg.py
@@ -31,7 +31,7 @@ from pytools import memoize_method, memoize_in, log_process
 from pytools.obj_array import flat_obj_array, make_obj_array
 
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
-from meshmode.dof_array import DOFArray
+from meshmode.dof_array import DOFArray, flat_norm
 from meshmode.array_context import (
         freeze, thaw,
         PyOpenCLArrayContext, make_loopy_program,
@@ -506,7 +506,7 @@ def main():
             # DOFArray would be nice?
             assert len(fields.u) == 1
             logger.info("[%05d] t %.5e / %.5e norm %.5e",
-                    istep, t, t_final, actx.np.linalg.norm(fields.u, 2))
+                    istep, t, t_final, flat_norm(fields.u, 2))
             vis.write_vtk_file("fld-wave-min-%04d.vtu" % istep, [
                 ("q", fields),
                 ])
@@ -514,7 +514,7 @@ def main():
         t += dt
         istep += 1
 
-    assert actx.np.linalg.norm(fields.u, 2) < 100
+    assert flat_norm(fields.u, 2) < 100
 
 
 if __name__ == "__main__":

--- a/examples/simple-dg.py
+++ b/examples/simple-dg.py
@@ -21,17 +21,27 @@ THE SOFTWARE.
 """
 
 
+from dataclasses import dataclass
 import numpy as np
 import numpy.linalg as la  # noqa
 import pyopencl as cl
 import pyopencl.array as cla  # noqa
 from pytools import memoize_method, memoize_in
 from pytools.obj_array import (
-        flat_obj_array, make_obj_array,
-        obj_array_vectorize)
+        flat_obj_array, make_obj_array)
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
-from meshmode.dof_array import freeze, thaw
-from meshmode.array_context import PyOpenCLArrayContext, make_loopy_program
+from meshmode.dof_array import (
+        DOFArray,
+        # deserialize_container_class, serialize_container,
+        map_dof_array_container
+        )
+from meshmode.array_context import (
+        freeze, thaw,
+        PyOpenCLArrayContext, make_loopy_program,
+        ArrayContainer, NumpyObjectArray,
+        array_container_vectorize,
+        DataclassArrayContainerWithArithmetic,
+        )
 
 
 # Features lost vs. https://github.com/inducer/grudge:
@@ -143,10 +153,6 @@ class DGDiscretization:
             raise ValueError(f"locations '{src}'->'{tgt}' not understood")
 
     def interp(self, src, tgt, vec):
-        if isinstance(vec, np.ndarray):
-            return obj_array_vectorize(
-                    lambda el: self.interp(src, tgt, el), vec)
-
         return self.get_connection(src, tgt)(vec)
 
     def get_discr(self, where):
@@ -233,8 +239,8 @@ class DGDiscretization:
         return actx.freeze(actx.from_numpy(matrix))
 
     def inverse_mass(self, vec):
-        if isinstance(vec, np.ndarray):
-            return obj_array_vectorize(self.inverse_mass, vec)
+        if not isinstance(vec, DOFArray):
+            return map_dof_array_container(self.inverse_mass, vec)
 
         @memoize_in(self, "elwise_linear_knl")
         def knl():
@@ -286,8 +292,8 @@ class DGDiscretization:
         return actx.freeze(actx.from_numpy(matrix))
 
     def face_mass(self, vec):
-        if isinstance(vec, np.ndarray):
-            return obj_array_vectorize(self.face_mass, vec)
+        if not isinstance(vec, DOFArray):
+            return map_dof_array_container(self.face_mass, vec)
 
         @memoize_in(self, "face_mass_knl")
         def knl():
@@ -329,21 +335,16 @@ class DGDiscretization:
 
 # {{{ trace pair
 
-class TracePair:
-    def __init__(self, where, interior, exterior):
-        self.where = where
-        self.interior = interior
-        self.exterior = exterior
+@dataclass(frozen=True)
+class TracePair(DataclassArrayContainerWithArithmetic):
+    where: str
+    interior: ArrayContainer
+    exterior: ArrayContainer
 
-    def __getitem__(self, index):
-        return TracePair(
-                self.where,
-                self.exterior[index],
-                self.interior[index])
-
-    def __len__(self):
-        assert len(self.exterior) == len(self.interior)
-        return len(self.exterior)
+    def __getattr__(self, name):
+        return array_container_vectorize(
+                lambda ary: getattr(ary, name),
+                self)
 
     @property
     def int(self):
@@ -360,72 +361,65 @@ class TracePair:
 
 def interior_trace_pair(discr, vec):
     i = discr.interp("vol", "int_faces", vec)
-    e = obj_array_vectorize(discr.opposite_face_connection(), i)
-    return TracePair("int_faces", i, e)
+    e = discr.opposite_face_connection()(i)
+    return TracePair("int_faces", interior=i, exterior=e)
 
 # }}}
 
 
 # {{{ wave equation bits
 
-def wave_flux(actx, discr, c, w_tpair):
-    u = w_tpair[0]
-    v = w_tpair[1:]
+def wave_flux(actx, discr, c, q_tpair):
+    u = q_tpair.u
+    v = q_tpair.v
 
-    normal = thaw(actx, discr.normal(w_tpair.where))
+    normal = thaw(actx, discr.normal(q_tpair.where))
 
-    flux_weak = flat_obj_array(
-            np.dot(v.avg, normal),
-            normal[0] * u.avg,
-            normal[1] * u.avg)
+    flux_weak = WaveState(
+            u=np.dot(v.avg, normal),
+            v=normal * u.avg)
 
     # upwind
     v_jump = np.dot(normal, v.ext-v.int)
-    flux_weak += flat_obj_array(
-            0.5*(u.ext-u.int),
-            0.5*normal[0]*v_jump,
-            0.5*normal[1]*v_jump,
-            )
+    flux_weak += WaveState(
+            u=0.5*(u.ext-u.int),
+            v=0.5*normal*v_jump)
 
-    flux_strong = flat_obj_array(
-            np.dot(v.int, normal),
-            u.int * normal[0],
-            u.int * normal[1],
+    flux_strong = WaveState(
+            u=np.dot(v.int, normal),
+            v=u.int * normal,
             ) - flux_weak
 
-    return discr.interp(w_tpair.where, "all_faces", c*flux_strong)
+    return discr.interp(q_tpair.where, "all_faces", c*flux_strong)
 
 
-def wave_operator(actx, discr, c, w):
-    u = w[0]
-    v = w[1:]
-
-    dir_u = discr.interp("vol", BTAG_ALL, u)
-    dir_v = discr.interp("vol", BTAG_ALL, v)
-    dir_bval = flat_obj_array(dir_u, dir_v)
-    dir_bc = flat_obj_array(-dir_u, dir_v)
+def wave_operator(actx, discr, c, q):
+    dir_q = discr.interp("vol", BTAG_ALL, q)
+    dir_bc = WaveState(u=-dir_q.u, v=dir_q.v)
 
     return (
-            - flat_obj_array(
-                -c*discr.div(v),
-                -c*discr.grad(u)
+            WaveState(
+                u=c*discr.div(q.v),
+                v=c*discr.grad(q.u)
                 )
-            +  # noqa: W504
+            -  # noqa: W504
             discr.inverse_mass(
                 discr.face_mass(
                     wave_flux(actx, discr, c=c,
-                        w_tpair=interior_trace_pair(discr, w))
+                        q_tpair=interior_trace_pair(discr, q))
                     + wave_flux(actx, discr, c=c,
-                        w_tpair=TracePair(BTAG_ALL, dir_bval, dir_bc))
+                        q_tpair=TracePair(BTAG_ALL, dir_q, dir_bc))
                     ))
                 )
-
 
 # }}}
 
 
 def rk4_step(y, t, h, f):
     k1 = f(t, y)
+    # FIXME: Test that these error if trying to add WaveState and 3-obj-array
+    #zz = y+k1
+    #zz = k1+y
     k2 = f(t+h/2, y + h/2*k1)
     k3 = f(t+h/2, y + h/2*k2)
     k4 = f(t+h, y + h*k3)
@@ -450,6 +444,27 @@ def bump(actx, discr, t=0):
             / source_width**2))
 
 
+@dataclass(frozen=True)
+class WaveState(DataclassArrayContainerWithArithmetic):
+    u: DOFArray
+    v: NumpyObjectArray
+
+    def __post_init__(self):
+        assert isinstance(self.v, np.ndarray) and self.v.dtype.char == "O"
+
+    @property
+    def array_context(self):
+        return self.u.array_context
+
+
+def ws_to_obj_array(ws):
+    return flat_obj_array(ws.u, ws.v)
+
+
+def obj_array_to_ws(ary):
+    return WaveState(u=ary[0], v=ary[1:])
+
+
 def main():
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
@@ -472,16 +487,16 @@ def main():
 
     discr = DGDiscretization(actx, mesh, order=order)
 
-    fields = flat_obj_array(
-            bump(actx, discr),
-            [discr.zeros(actx) for i in range(discr.dim)]
+    fields = WaveState(
+            u=bump(actx, discr),
+            v=make_obj_array([discr.zeros(actx) for i in range(discr.dim)]),
             )
 
     from meshmode.discretization.visualization import make_visualizer
     vis = make_visualizer(actx, discr.volume_discr)
 
-    def rhs(t, w):
-        return wave_operator(actx, discr, c=1, w=w)
+    def rhs(t, q):
+        return wave_operator(actx, discr, c=1, q=q)
 
     t = 0
     t_final = 3
@@ -492,18 +507,17 @@ def main():
         if istep % 10 == 0:
             # FIXME: Maybe an integral function to go with the
             # DOFArray would be nice?
-            assert len(fields[0]) == 1
-            print(istep, t, actx.np.linalg.norm(fields[0], 2))
+            assert len(fields.u) == 1
+            print(istep, t, actx.np.linalg.norm(fields.u, 2))
             vis.write_vtk_file("fld-wave-min-%04d.vtu" % istep,
                     [
-                        ("u", fields[0]),
-                        ("v", fields[1:]),
+                        ("q", fields),
                         ])
 
         t += dt
         istep += 1
 
-    assert actx.np.linalg.norm(fields[0], 2) < 100
+    assert actx.np.linalg.norm(fields.u, 2) < 100
 
 
 if __name__ == "__main__":

--- a/examples/simple-dg.py
+++ b/examples/simple-dg.py
@@ -37,7 +37,7 @@ from meshmode.array_context import (
         PyOpenCLArrayContext, make_loopy_program,
         ArrayContainer,
         map_array_container,
-        ArrayContainerWithArithmetic,
+        with_container_arithmetic,
         dataclass_array_container,
         )
 
@@ -336,9 +336,11 @@ class DGDiscretization:
 
 # {{{ trace pair
 
+@with_container_arithmetic(
+        bcast_obj_array=False, eq_comparison=False, rel_comparison=False)
 @dataclass_array_container
 @dataclass(frozen=True)
-class TracePair(ArrayContainerWithArithmetic):
+class TracePair:
     where: str
     interior: ArrayContainer
     exterior: ArrayContainer
@@ -419,9 +421,6 @@ def wave_operator(actx, discr, c, q):
 
 def rk4_step(y, t, h, f):
     k1 = f(t, y)
-    # FIXME: Test that these error if trying to add WaveState and 3-obj-array
-    #zz = y+k1
-    #zz = k1+y
     k2 = f(t+h/2, y + h/2*k1)
     k3 = f(t+h/2, y + h/2*k2)
     k4 = f(t+h, y + h*k3)
@@ -446,9 +445,10 @@ def bump(actx, discr, t=0):
             / source_width**2))
 
 
+@with_container_arithmetic(bcast_obj_array=True, rel_comparison=True)
 @dataclass_array_container
 @dataclass(frozen=True)
-class WaveState(ArrayContainerWithArithmetic):
+class WaveState:
     u: DOFArray
     v: np.ndarray  # [object]
 

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -24,7 +24,7 @@ import operator
 from dataclasses import fields
 from functools import partial, singledispatch, update_wrapper
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Iterable, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Iterable, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -43,7 +43,6 @@ __doc__ = """
 .. autoclass:: ArrayContainer
 .. autofunction:: is_array_container
 .. autofunction:: serialize_container
-.. autofunction:: deserialize_container_class
 .. autofunction:: deserialize_container
 .. autofunction:: get_container_context
 .. autofunction:: get_container_context_recursively
@@ -56,6 +55,7 @@ __doc__ = """
 .. autofunction:: map_array_container
 .. autofunction:: multimap_array_container
 .. autofunction:: freeze
+.. autofunction:: thaw_impl
 .. autofunction:: thaw
 
 .. autoclass:: ArrayContext
@@ -105,10 +105,6 @@ def _loopy_get_default_entrypoint(t_unit):
 
 # {{{ ArrayContainer
 
-class _ArrayContextNotProvided:
-    pass
-
-
 class ArrayContainer:
     r"""A generic container for the array type supported by the
     :class:`ArrayContext`.
@@ -122,8 +118,7 @@ class ArrayContainer:
     * Serialization functionality is implemented in :func:`serialize_container`
       and :func:`deserialize_container`. This allows enumeration of the
       component arrays in a container and the construction of modified
-      containers from an iterable of those component arrays. Deserialization
-      may be registered using :func:`deserialize_container_class`.
+      containers from an iterable of those component arrays.
     * :func:`get_container_context` retrieves the :class:`ArrayContext` from
       a container, if it has one.
 
@@ -140,7 +135,7 @@ def is_array_container(ary: object):
 
 
 @is_array_container.register(ArrayContainer)
-def _(ary: ArrayContainer):
+def _is_array_container_ac(ary: ArrayContainer):
     return True
 
 
@@ -166,18 +161,8 @@ def serialize_container(ary: ArrayContainer) -> Iterable[Tuple[Any, Any]]:
 
 
 @singledispatch
-def deserialize_container_class(cls: type, template: Any,
-        iterable: Iterable[Tuple[Any, Any]], *,
-        actx: Optional["ArrayContext"] = None):
-    """Serves as the :func:`functools.singledispatch` registration target for
-    container deserialization through :func:`deserialize_container`.
-    """
-    raise NotImplementedError(cls.__name__)
-
-
-def deserialize_container(cls: type, template: Any,
-        iterable: Iterable[Tuple[Any, Any]], *,
-        actx: Optional["ArrayContext"] = _ArrayContextNotProvided):
+def deserialize_container(template: Any,
+        iterable: Iterable[Tuple[Any, Any]]):
     """Deserialize an iterable into an array container.
 
     :param template: an instance of an existing object that
@@ -189,11 +174,7 @@ def deserialize_container(cls: type, template: Any,
         container, if it requires one at all. If not provided, attempt to get
         a context from the *template*.
     """
-    if actx is _ArrayContextNotProvided:
-        actx = get_container_context(template)
-
-    return deserialize_container_class.dispatch(cls)(
-            cls, template, iterable, actx=actx)
+    raise NotImplementedError(type(template).__name__)
 
 
 @singledispatch
@@ -212,23 +193,23 @@ def get_container_context(ary: ArrayContainer):
 # {{{ object arrays as array containers
 
 @is_array_container.register(np.ndarray)
-def _(ary: np.ndarray):
+def _is_array_container_ndarray(ary: np.ndarray):
     return ary.dtype.char == "O"
 
 
 @serialize_container.register(np.ndarray)
-def _(ary: np.ndarray):
+def _serialize_container_ndarray(ary: np.ndarray):
     assert ary.dtype.char == "O"
     return np.ndenumerate(ary)
 
 
-@deserialize_container_class.register(np.ndarray)
-def _(cls: type, template: Any, iterable: Iterable[Tuple[Any, Any]], *,
-        actx: Optional["ArrayContext"] = None):
+@deserialize_container.register(np.ndarray)
+def _deserialize_container_ndarray(
+        template: Any, iterable: Iterable[Tuple[Any, Any]]):
     # disallow subclasses
-    assert cls is np.ndarray
+    assert type(template) is np.ndarray
 
-    result = cls(template.shape, dtype=object)
+    result = type(template)(template.shape, dtype=object)
     for i, subary in iterable:
         result[i] = subary
 
@@ -434,7 +415,7 @@ class ArrayContainerWithArithmetic(ArrayContainer):
 
 
 @get_container_context.register(ArrayContainerWithArithmetic)
-def _(ary: ArrayContainerWithArithmetic):
+def _get_array_container_ac_arith(ary: ArrayContainerWithArithmetic):
     return ary.array_context
 
 # }}}
@@ -457,14 +438,13 @@ class DataclassArrayContainerWithArithmetic(
 
 
 @serialize_container.register(DataclassArrayContainer)
-def _(ary: DataclassArrayContainer):
+def _serialize_dataclass_ac(ary: DataclassArrayContainer):
     return ((var.name, getattr(ary, var.name)) for var in fields(ary))
 
 
-@deserialize_container_class.register(DataclassArrayContainer)
-def _(cls, template: Any, iterable: Iterable[Tuple[Any, Any]], *,
-        actx: Optional["ArrayContext"] = None):
-    return cls(**dict(iterable))
+@deserialize_container.register(DataclassArrayContainer)
+def _deserialize_dataclass_ac(template: Any, iterable: Iterable[Tuple[Any, Any]]):
+    return type(template)(**dict(iterable))
 
 # }}}
 
@@ -492,8 +472,7 @@ def _zip_containers(arys):
         yield key, value
 
 
-def _map_array_container_with_context(f, ary, *,
-        actx=_ArrayContextNotProvided,
+def _map_array_container(f, ary, *,
         leaf_cls=None,
         recursive=False):
     """Helper for :func:`map_array_container`.
@@ -508,26 +487,21 @@ def _map_array_container_with_context(f, ary, *,
     if type(ary) is leaf_cls:  # type(ary) is never None
         return f(ary)
     elif is_array_container(ary):
-        array_context = actx
-        if array_context is _ArrayContextNotProvided:
-            array_context = get_container_context(ary)
-
         if recursive:
-            f = partial(_map_array_container_with_context,
-                    f, actx=actx, leaf_cls=leaf_cls, recursive=True)
+            f = partial(_map_array_container,
+                    f, leaf_cls=leaf_cls, recursive=True)
 
-        return deserialize_container(type(ary), ary, (
+        return deserialize_container(ary, (
                 (key, f(subary)) for key, subary in serialize_container(ary)
-                ), actx=array_context)
+                ))
     else:
         return f(ary)
 
 
 def _multimap_array_container_only_unchecked(f, *args,
-        actx=_ArrayContextNotProvided,
         leaf_cls=None,
         recursive=False):
-    r"""Version of :func:`_multimap_array_container_with_context` that assumes
+    r"""Version of :func:`_multimap_array_container` that assumes
     all *args* are :class:`ArrayContainer`\ s of the same type.
 
     No checks are performed.
@@ -537,21 +511,16 @@ def _multimap_array_container_only_unchecked(f, *args,
             or not is_array_container(template_ary)):
         return f(*args)
 
-    array_context = actx
-    if array_context is _ArrayContextNotProvided:
-        array_context = get_container_context(template_ary)
-
     if recursive:
         f = partial(_multimap_array_container_only_unchecked,
-                f, actx=actx, leaf_cls=leaf_cls, recursive=True)
+                f, leaf_cls=leaf_cls, recursive=True)
 
-    return deserialize_container(type(template_ary), template_ary, (
+    return deserialize_container(template_ary, (
         (key, f(*subarys)) for key, subarys in _zip_containers(args)
-        ), actx=array_context)
+        ))
 
 
-def _multimap_array_container_with_context(f, *args,
-        actx=_ArrayContextNotProvided,
+def _multimap_array_container(f, *args,
         leaf_cls=None,
         recursive=False):
     """Helper for :func:`multimap_array_container`.
@@ -580,15 +549,11 @@ def _multimap_array_container_with_context(f, *args,
 
     if len(container_indices) == len(args):
         return _multimap_array_container_only_unchecked(f, *args,
-                actx=actx, leaf_cls=leaf_cls, recursive=recursive)
-
-    array_context = actx
-    if array_context is _ArrayContextNotProvided:
-        array_context = get_container_context(template_ary)
+                leaf_cls=leaf_cls, recursive=recursive)
 
     if recursive:
-        f = partial(_multimap_array_container_with_context,
-                f, actx=actx, leaf_cls=leaf_cls, recursive=True)
+        f = partial(_multimap_array_container,
+                f, leaf_cls=leaf_cls, recursive=True)
 
     result = []
     new_args = list(args)
@@ -599,9 +564,7 @@ def _multimap_array_container_with_context(f, *args,
 
         result.append((key, f(*new_args)))
 
-    return deserialize_container(
-            type(template_ary), template_ary, tuple(result),
-            actx=array_context)
+    return deserialize_container(template_ary, tuple(result))
 
 
 def array_container_vectorize(f: Callable[[Any], Any], ary):
@@ -615,7 +578,7 @@ def array_container_vectorize(f: Callable[[Any], Any], ary):
     :param ary: a (potentially nested) structure of :class:`ArrayContainer`\ s,
         or an instance of a base array type.
     """
-    return _map_array_container_with_context(f, ary, recursive=False)
+    return _map_array_container(f, ary, recursive=False)
 
 
 def array_container_vectorize_n_args(f: Callable[[Any], Any], *args):
@@ -630,7 +593,7 @@ def array_container_vectorize_n_args(f: Callable[[Any], Any], *args):
     :param args: all :class:`ArrayContainer` arguments must be of the same
         type and with the same structure (same number of components, etc.).
     """
-    return _multimap_array_container_with_context(f, *args, recursive=False)
+    return _multimap_array_container(f, *args, recursive=False)
 
 
 def map_array_container(f: Callable[[Any], Any], ary):
@@ -641,7 +604,7 @@ def map_array_container(f: Callable[[Any], Any], ary):
     :param ary: a (potentially nested) structure of :class:`ArrayContainer`\ s,
         or an instance of a base array type.
     """
-    return _map_array_container_with_context(f, ary, recursive=True)
+    return _map_array_container(f, ary, recursive=True)
 
 
 def mapped_over_array_containers(f: Callable[[Any], Any]):
@@ -659,7 +622,7 @@ def multimap_array_container(f: Callable[[Any], Any], *args):
     :param args: all :class:`ArrayContainer` arguments must be of the same
         type and with the same structure (same number of components, etc.).
     """
-    return _multimap_array_container_with_context(f, *args, recursive=True)
+    return _multimap_array_container(f, *args, recursive=True)
 
 
 def multimapped_over_array_containers(f: Callable[[Any], Any]):
@@ -671,29 +634,49 @@ def multimapped_over_array_containers(f: Callable[[Any], Any]):
     return wrapper
 
 
-def freeze(ary):
+@singledispatch
+def freeze(ary, actx=None):
     r"""Freezes recursively by going through all components of the
     :class:`ArrayContainer` *ary*.
 
     :param ary: a :meth:`~ArrayContext.thaw`\ ed :class:`ArrayContainer`.
+
+    Array container types may use :func:`functools.singledispatch` ``.register`` to
+    register additional implementations.
+
+    See :meth:`ArrayContext.thaw`.
     """
-    def _freeze(subary, actx=None):
-        if is_array_container(subary):
-            if actx is None:
-                actx = get_container_context(subary)
-
-            return _map_array_container_with_context(
-                    partial(_freeze, actx=actx),
-                    subary, actx=None, recursive=False)
+    if is_array_container(ary):
+        return _map_array_container(
+                partial(freeze, actx=actx), ary,
+                recursive=False)
+    else:
+        if actx is None:
+            raise TypeError(
+                    f"cannot freeze arrays of type {type(ary).__name__} "
+                    "when actx is not supplied. Try calling actx.freeze "
+                    "directly or supplying an array context")
         else:
-            return actx.freeze(subary)
+            return actx.freeze(ary)
 
-    if not is_array_container(ary):
-        raise TypeError(
-                f"cannot freeze arrays of type {type(ary).__name__}; "
-                "try calling 'ArrayContext.freeze' directly")
 
-    return _freeze(ary)
+@singledispatch
+def thaw_impl(ary, actx):
+    """Serves as the registration point (using :func:`functools.singledispatch`
+    ``.register`` to register additional implementations for :func:`thaw`.
+
+    .. note::
+
+        This is separate from :func:`thaw` because of argument order. Use of
+        :func:`functools.singledispatch` requires the 'dispatching' argument
+        to come first.
+    """
+    if is_array_container(ary):
+        return deserialize_container(ary,
+                ((key, thaw_impl(subary, actx))
+                    for key, subary in serialize_container(ary)))
+    else:
+        return actx.thaw(ary)
 
 
 def thaw(actx, ary):
@@ -701,14 +684,13 @@ def thaw(actx, ary):
     :class:`ArrayContainer` *ary*.
 
     :param ary: a :meth:`~ArrayContext.freeze`\ ed :class:`ArrayContainer`.
-    """
-    if not is_array_container(ary):
-        raise TypeError(
-                f"cannot thaw arrays of type {type(ary).__name__}; "
-                "try calling 'ArrayContext.thaw' directly")
 
-    return _map_array_container_with_context(
-            actx.thaw, ary, actx=actx, recursive=True)
+    Array container types may use :func:`functools.singledispatch` ``.register``
+    (with :func:`thaw_impl`) to register additional implementations.
+
+    See :meth:`ArrayContext.thaw`.
+    """
+    return thaw_impl(ary, actx)
 
 # }}}
 

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -109,8 +109,9 @@ class ArrayContainer:
     r"""A generic container for the array type supported by the
     :class:`ArrayContext`.
 
-    The functionality for the container is implemented through
-    :func:`functools.singledispatch`. The following functions are required
+    The functionality required for the container to operated is supplied via
+    :func:`functools.singledispatch`. Implementations of the following functions need
+    to be registered for a type serving as an :class:`ArrayContainer`:
 
     * :func:`serialize_container` for serialization, which gives the components
       of the array.
@@ -360,9 +361,9 @@ def with_container_arithmetic(
     :arg bcast_number: If *True*, numbers broadcast over the container
         (with the container as the 'outer' structure).
     :arg bcast_obj_array: If *True*, :mod:`numpy` object arrays broadcast over
-        the container.  (with the container as the 'inner' structure).
+        the container.  (with the container as the 'inner' structure)
     :arg bcast_numpy_array: If *True*, any :class:`numpy.ndarray` will broadcast
-        over the container.  (with the container as the 'inner' structure).
+        over the container.  (with the container as the 'inner' structure)
     :arg arithmetic: Implement the conventional arithmetic operators, including
         ``**``, :func:`divmod`, and ``//``. Also includes ``+`` and ``-`` as well as
         :func:`abs`.
@@ -373,7 +374,7 @@ def with_container_arithmetic(
         In that case, if *eq_comparison* is unspecified, it is also set to
         *True*.
 
-    Each operator class also includes the "reverse" operator class if applicable.
+    Each operator class also includes the "reverse" operators if applicable.
 
     .. note::
 
@@ -575,7 +576,7 @@ def dataclass_array_container(cls):
 
     Attributes that are not array containers are allowed. In order to decide
     whether an attribute is an array container, the declared attribute type
-    is checked for whether it is a subclass of :class:`ArrayContainer`.
+    is checked via :func:`is_array_container_type`.
     """
     from dataclasses import is_dataclass
     assert is_dataclass(cls)
@@ -792,6 +793,8 @@ def rec_multimap_array_container(f: Callable[[Any], Any], *args):
 
 def multimapped_over_array_containers(f: Callable[[Any], Any]):
     """Decorator around :func:`rec_multimap_array_container`."""
+    # can't use functools.partial, because its result is insufficiently
+    # function-y to be used as a method definition.
     def wrapper(*args):
         return rec_multimap_array_container(f, *args)
 

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -816,9 +816,7 @@ def freeze(ary, actx=None):
     See :meth:`ArrayContext.thaw`.
     """
     if is_array_container(ary):
-        return _map_array_container_impl(
-                partial(freeze, actx=actx), ary,
-                recursive=False)
+        return map_array_container(partial(freeze, actx=actx), ary)
     else:
         if actx is None:
             raise TypeError(

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -565,7 +565,7 @@ def _multimap_array_container_with_context(f, *args,
     container_indices = [
             i for i, arg in enumerate(args)
             if isinstance(arg, ArrayContainer)
-            or (leaf_cls is not None and type(arg) is not leaf_cls)
+            and (leaf_cls is None or type(arg) is not leaf_cls)
             ]
 
     if not container_indices:

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -217,8 +217,10 @@ def get_container_context(ary: ArrayContainer):
     """
     return None
 
+# }}}
 
-# {{{ object arrays
+
+# {{{ object arrays as array containers
 
 @is_array_container.register(np.ndarray)
 def _(ary: np.ndarray):
@@ -243,6 +245,10 @@ def _(cls: type, template: Any, iterable: Iterable[Tuple[Any, Any]], *,
 
     return result
 
+# }}}
+
+
+# {{{ get_container_context_recursively
 
 def get_container_context_recursively(ary: Any):
     """Walks the :class:`ArrayContainer` hierarchy to find an :class:`ArrayContext`
@@ -275,8 +281,6 @@ def get_container_context_recursively(ary: Any):
             assert actx is context
 
     return actx
-
-# }}}
 
 # }}}
 

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -218,11 +218,8 @@ def _(ary: np.ndarray):
 
 
 @serialize_container.register(np.ndarray)
-def _(ary: Union[list, tuple, np.ndarray]):
-    if ary.dtype.char != "O":
-        raise NotImplementedError(
-                f"serialization for 'numpy.ndarray' of dtype '{ary.dtype}'")
-
+def _(ary: np.ndarray):
+    assert ary.dtype.char == "O"
     return np.ndenumerate(ary)
 
 

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -271,9 +271,6 @@ def get_container_context_recursively(ary: Any):
 
     contexts = [c for c in contexts if c is not None]
     if contexts:
-        # FIXME: is `is` a bit strict here? maybe `type(a) is type(b)`?
-        # this would allow, e.g. different components to have different
-        # queues in an PyOpenCLArrayContext
         actx = single_valued(contexts, equality_pred=operator.is_)
 
     return actx

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -576,7 +576,7 @@ def dataclass_array_container(cls):
 
     Attributes that are not array containers are allowed. In order to decide
     whether an attribute is an array container, the declared attribute type
-    is checked via :func:`is_array_container_type`.
+    is checked by the criteria from :func:`is_array_container`.
     """
     from dataclasses import is_dataclass
     assert is_dataclass(cls)
@@ -679,8 +679,9 @@ def _multimap_array_container_impl(f, *args, leaf_cls=None, recursive=False):
     """
     def rec(*_args):
         template_ary = _args[container_indices[0]]
-        assert all(type(arys[i]) is type(template_ary) for i in container_indices[1:]), \
-                "expected type '{type(template_ary).__name__}'"        
+        assert all(
+                type(_args[i]) is type(template_ary) for i in container_indices[1:]
+                ), "expected type '{type(template_ary).__name__}'"
 
         if (type(template_ary) is leaf_cls
                 or not is_array_container(template_ary)):

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -188,7 +188,7 @@ def deserialize_container(cls: type,
         an :class:`ArrayContext`.
     :param template: an instance of an existing object of class *cls* that
         can be used to aid in the deserialization. For a similar choice
-        see :meth:`numpy.ndarray.__array_finalize__`.
+        see :attr:`~numpy.class.__array_finalize__`.
     """
     return deserialize_container_class.dispatch(cls)(
             cls, iterable, actx=actx, template=template)

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -41,6 +41,7 @@ __doc__ = """
 .. autoclass:: FirstAxisIsElementsTag
 
 .. autoclass:: ArrayContainer
+.. autofunction:: is_array_container
 .. autofunction:: serialize_container
 .. autofunction:: deserialize_container
 .. autofunction:: get_container_context
@@ -110,12 +111,20 @@ class ArrayContainerMeta(type):
 
 
 class ArrayContainer(metaclass=ArrayContainerMeta):
-    """A generic container for the array type supported by the
+    r"""A generic container for the array type supported by the
     :class:`ArrayContext`.
 
-    Serialization functionality is implemented in :func:`serialize_container`
-    and :func:`deserialize_container` using the :func:`functools.singledispatch`
-    mechanism.
+    The functionality for the container is implement through
+    :func:`functools.singledispatch`. The following methods are required
+
+    * :func:`is_array_container` allows registering foreign types as containers.
+      For example, object :class:`~numpy.ndarray`\ s are considered containers
+      and ``isinstance(ary, ArrayContainer)`` will be *True*.
+    * Serialization functionality is implemented in :func:`serialize_container`
+      and :func:`deserialize_container`. This allows accessing the components
+      of the container.
+    * :func:`get_container_context` retrieves the :class:`ArrayContext` from
+      a container, if it has one.
 
     The container is meant to work in a similar way to JAX's
     `PyTrees <https://jax.readthedocs.io/en/latest/pytrees.html>`__.

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -263,17 +263,20 @@ def get_container_context_recursively(ary: Any):
     if actx is not None:
         return actx
 
-    # try getting it recursively
-    contexts = [
-            get_container_context_recursively(subary)
-            for _, subary in serialize_container(ary)
-            ]
+    first_context = None
+    for _, subary in serialize_container(ary):
+        context = get_container_context_recursively(subary)
+        if context is None:
+            continue
 
-    contexts = [c for c in contexts if c is not None]
-    if contexts:
-        actx = single_valued(contexts, equality_pred=operator.is_)
+        if not __debug__:
+            return context
+        elif first_context is None:
+            first_context = context
+        else:
+            assert first_context is context
 
-    return actx
+    return first_context
 
 # }}}
 

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -637,9 +637,8 @@ def dataclass_array_container(cls):
             _deserialize_init_arrays_code_{lower_cls_name})
         """)
 
-    exec_dict = {"cls": cls}
+    exec_dict = {"cls": cls, "_MODULE_SOURCE_CODE": serialize_code}
     exec(compile(serialize_code, "<generated code>", "exec"), exec_dict)
-    exec_dict["_MODULE_SOURCE_CODE"] = serialize_code
 
     return cls
 

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -481,26 +481,6 @@ def _deserialize_dataclass_container(
 
 # {{{ ArrayContainer traversal
 
-def _zip_containers(arys):
-    r"""
-    :param arys: an iterable of :class:`ArrayContainer`\ s of the same type
-        and with the same number of components.
-    :returns: an iterable of tuples ``(key, subarys)``, where *key* is the
-        common key and *subarys* are all the components of containers in *arys*
-        corresponding to that key.
-    """
-    keys = (key for key, _ in serialize_container(arys[0]))
-    subarys = [[subary for _, subary in serialize_container(ary)] for ary in arys]
-
-    from pytools import is_single_valued
-    if not is_single_valued([len(ary) for ary in subarys]):
-        raise ValueError(
-                "all ArrayContainers must have the same number of components")
-
-    for key, value in zip(keys, zip(*subarys)):
-        yield key, value
-
-
 def _map_array_container_impl(f, ary, *, leaf_cls=None, recursive=False):
     """Helper for :func:`rec_map_array_container`.
 

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -252,6 +252,8 @@ def get_container_context_recursively(ary: Any):
     an assertion error is raised.
     """
     actx = None
+    if not isinstance(ary, ArrayContainer):
+        return actx
 
     # try getting the array context directly
     if isinstance(ary, ArrayContainer):

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -439,6 +439,14 @@ def with_container_arithmetic(
     # }}}
 
     def wrap(cls):
+        if (not hasattr(cls, "_serialize_init_arrays_code")
+                or not hasattr(cls, "_deserialize_init_arrays_code")):
+            raise TypeError(f"class '{cls.__name__}' must provide serialization "
+                    "code to generate arithmetic operations by implementing "
+                    "'_serialize_init_arrays_code' and "
+                    "'_deserialize_init_arrays_code'. If this is a dataclass, "
+                    "use the 'dataclass_array_container' decorator first.")
+
         from pytools.codegen import CodeGenerator
         gen = CodeGenerator()
         gen("""
@@ -458,7 +466,7 @@ def with_container_arithmetic(
             if op_cls not in desired_op_classes:
                 continue
 
-            fname = f"{cls.__name__.lower()}_{dunder_name}"
+            fname = f"_{cls.__name__.lower()}_{dunder_name}"
             init_args = cls._deserialize_init_arrays_code("arg1", {
                     key_arg1: _format_unary_op_str(op_str, expr_arg1)
                     for key_arg1, expr_arg1 in
@@ -481,7 +489,7 @@ def with_container_arithmetic(
 
             # {{{ "forward" binary operators
 
-            fname = f"{cls.__name__.lower()}_{dunder_name}"
+            fname = f"_{cls.__name__.lower()}_{dunder_name}"
             zip_init_args = cls._deserialize_init_arrays_code("arg1", {
                     same_key(key_arg1, key_arg2):
                     _format_binary_op_str(op_str, expr_arg1, expr_arg2)
@@ -516,7 +524,7 @@ def with_container_arithmetic(
             # {{{ "reverse" binary operators
 
             if reversible:
-                fname = f"{cls.__name__.lower()}_r{dunder_name}"
+                fname = f"_{cls.__name__.lower()}_r{dunder_name}"
                 bcast_init_args = cls._deserialize_init_arrays_code("arg2", {
                         key_arg2: _format_binary_op_str(
                             op_str, "arg1", expr_arg2)

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -388,7 +388,7 @@ def _(ary: ArrayContainerWithArithmetic):
 
 class DataclassContainer(ArrayContainer):
     """An :class:`ArrayContainer` that implements serialization and
-    deserialization of :class:`~dataclasses.dataclass` fields.
+    deserialization of :func:`~dataclasses.dataclass` fields.
     """
 
 
@@ -396,7 +396,7 @@ class DataclassContainerWithArithmetic(
         ArrayContainerWithArithmetic,
         DataclassContainer):
     """An :class:`DataclassContainer` where each field is assumed to
-    support arithmetic, e.g. thought :class:`ArrayContainerWithArithmetic`.
+    support arithmetic, e.g. through :class:`ArrayContainerWithArithmetic`.
     """
 
 

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -743,7 +743,12 @@ def map_array_container(f: Callable[[Any], Any], ary):
     :param ary: a (potentially nested) structure of :class:`ArrayContainer`\ s,
         or an instance of a base array type.
     """
-    return _map_array_container_impl(f, ary, recursive=False)
+    if is_array_container(ary):
+        return deserialize_container(ary, [
+                (key, f(subary)) for key, subary in serialize_container(ary)
+                ])
+    else:
+        return f(ary)
 
 
 def multimap_array_container(f: Callable[[Any], Any], *args):

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -505,7 +505,7 @@ def _map_array_container_with_context(f, ary, *,
         specific container classes. By default, the recursion is stopped when
         a non-:class:`ArrayContainer` class is encountered.
     """
-    if leaf_cls is not None and type(ary) is leaf_cls:
+    if type(ary) is leaf_cls:  # type(ary) is never None
         return f(ary)
     elif is_array_container(ary):
         array_context = actx

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -332,7 +332,7 @@ class ArrayContainerWithArithmetic(ArrayContainer):
         elif isinstance(arg1, Number) and isinstance(arg2, ArrayContainer):
             return map_array_container(lambda subary: op(arg1, subary), arg2)
         else:
-            NotImplementedError(
+            raise NotImplementedError(
                 f"operation '{op.__name__}' for arrays of type "
                 f"'{type(arg1).__name__}' and '{type(arg2).__name__}'")
 

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -693,13 +693,13 @@ def _multimap_array_container_impl(f, *args, leaf_cls=None, recursive=False):
                 serialize_container(_args[i]) for i in container_indices
                 ]):
             key = None
-            for i, subary in zip(container_indices, subarys):
+            for i, (subkey, subary) in zip(container_indices, subarys):
                 if key is None:
-                    key = subary[0]
+                    key = subkey
                 else:
-                    assert key == subary[0]
+                    assert key == subkey
 
-                new_args[i] = subary[1]
+                new_args[i] = subary
 
             result.append((key, frec(*new_args)))
 

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -104,6 +104,9 @@ class ArrayContainer(ABC):
     Serialization functionality is implemented in :func:`serialize_container`
     and :func:`deserialize_container` using the :func:`functools.singledispatch`
     mechanism.
+
+    The container is meant to work in a similar way to JAX's
+    `PyTrees <https://jax.readthedocs.io/en/latest/pytrees.html>`__.
     """
 
 

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -593,8 +593,8 @@ def _multimap_array_container_with_context(f, *args,
     new_args = list(args)
 
     for key, subarys in _zip_containers([args[i] for i in container_indices]):
-        for i in container_indices:
-            new_args[i] = subarys[i]
+        for i, subary in zip(container_indices, subarys):
+            new_args[i] = subary
 
         result.append((key, f(*new_args)))
 

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -677,13 +677,10 @@ def _multimap_array_container_impl(f, *args, leaf_cls=None, recursive=False):
         specific container classes. By default, the recursion is stopped when
         a non-:class:`ArrayContainer` class is encountered.
     """
-    def is_same_type(arys, template_ary):
-        return all(type(arys[i]) is type(template_ary) for i in container_indices)
-
     def rec(*_args):
         template_ary = _args[container_indices[0]]
-        assert is_same_type(_args, template_ary), \
-                "expected type '{type(template_ary).__name__}'"
+        assert all(type(arys[i]) is type(template_ary) for i in container_indices[1:]), \
+                "expected type '{type(template_ary).__name__}'"        
 
         if (type(template_ary) is leaf_cls
                 or not is_array_container(template_ary)):

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -451,14 +451,14 @@ def _(ary: DataclassArrayContainer):
     return z
 
 
-@deserialize_container_class.register(DataclassArrayContainer)
+@deserialize_container.register(DataclassArrayContainer)
 def _(template: DataclassArrayContainer, iterable: Iterable[Tuple[Any, Any]]):
     kwargs = dict(iterable)
     # FIXME: These field lists could be generated statically.
-    for fld in fields(cls):
+    for fld in fields(template):
         if not issubclass(fld.type, (ArrayContainer, NumpyObjectArray)):
             kwargs[fld.name] = getattr(template, fld.name)
-    return cls(**kwargs)
+    return type(template)(**kwargs)
 
 # }}}
 

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -24,14 +24,14 @@ import operator
 from dataclasses import fields
 from functools import partial, singledispatch, update_wrapper
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Iterable, Sequence, Tuple, Union
+from typing import Any, Callable, Iterable, Sequence, Tuple, Union, Optional
 
 import numpy as np
 
 import loopy as lp
 from loopy.version import MOST_RECENT_LANGUAGE_VERSION
 
-from pytools import memoize_method, memoize
+from pytools import memoize_method
 from pytools.tag import Tag
 
 
@@ -42,14 +42,14 @@ __doc__ = """
 
 .. autoclass:: ArrayContainer
 .. autofunction:: is_array_container
+.. autofunction:: is_array_container_type
 .. autofunction:: serialize_container
 .. autofunction:: deserialize_container
 .. autofunction:: get_container_context
 .. autofunction:: get_container_context_recursively
 
 .. autoclass:: ArrayContainerWithArithmetic
-.. autoclass:: DataclassArrayContainer
-.. autoclass:: DataclassArrayContainerWithArithmetic
+.. autofunction:: dataclass_array_container
 .. autofunction:: map_array_container
 .. autofunction:: multimap_array_container
 .. autofunction:: rec_map_array_container
@@ -112,35 +112,34 @@ class ArrayContainer:
     The functionality for the container is implemented through
     :func:`functools.singledispatch`. The following methods are required
 
-    * :func:`is_array_container` allows registering foreign types as containers.
-      For example, object :class:`~numpy.ndarray`\ s are considered containers
-      and ``isinstance(ary, ArrayContainer)`` will be *True*.
     * Serialization functionality is implemented in :func:`serialize_container`
       and :func:`deserialize_container`. This allows enumeration of the
       component arrays in a container and the construction of modified
       containers from an iterable of those component arrays.
+      :func:`is_array_container` will return *True* for types that have
+      a container serialization function registered.
+    * Packages may register their own types as array containers. They must not
+      register other types (e.g. :class:`list`) as array containers.
     * :func:`get_container_context` retrieves the :class:`ArrayContext` from
       a container, if it has one.
+    * The type :class:`numpy.ndarray` is considered an array container, but
+      only arrays with dtype *object* may be used as such. (This is so
+      because object arrays cannot be distinguished from non-object arrays
+      via their type.)
 
     The container and its serialization interface has goals and uses
     approaches similar to JAX's
     `PyTrees <https://jax.readthedocs.io/en/latest/pytrees.html>`__,
     however its implementation differs a bit.
+
+    .. note::
+
+        This class is used in type annotation. Inheriting from it confers no
+        special meaning or behavior.
     """
 
 
-@singledispatch
-def is_array_container(ary: object):
-    return False
-
-
-@is_array_container.register(ArrayContainer)
-def _is_array_container_ac(ary: ArrayContainer):
-    return True
-
-
-@singledispatch
-def serialize_container(ary: ArrayContainer) -> Iterable[Tuple[Any, Any]]:
+def _serialize_container_default(ary: ArrayContainer) -> Iterable[Tuple[Any, Any]]:
     r"""Serialize the array container into an iterable over its components.
 
     The order of the components and their identifiers are entirely under
@@ -160,6 +159,9 @@ def serialize_container(ary: ArrayContainer) -> Iterable[Tuple[Any, Any]]:
     raise NotImplementedError(type(ary).__name__)
 
 
+serialize_container = singledispatch(_serialize_container_default)
+
+
 @singledispatch
 def deserialize_container(template: Any,
         iterable: Iterable[Tuple[Any, Any]]):
@@ -177,8 +179,25 @@ def deserialize_container(template: Any,
     raise NotImplementedError(type(template).__name__)
 
 
+def is_array_container_type(cls: Any) -> bool:
+    """"Return *True* if the type*cls* has a registered implementation of
+    :func:`serialize_container`, or if it is :class:`ArrayContainer`.
+    """
+    return (
+            serialize_container.dispatch(cls) is not _serialize_container_default
+            or cls is ArrayContainer)
+
+
+def is_array_container(ary: Any) -> bool:
+    """Return *True* if the instance *ary* has a registered implementation of
+    :func:`serialize_container`.
+    """
+    return serialize_container.dispatch(ary.__class__) \
+            is not _serialize_container_default
+
+
 @singledispatch
-def get_container_context(ary: ArrayContainer):
+def get_container_context(ary: ArrayContainer) -> Optional["ArrayContext"]:
     """Retrieves the :class:`ArrayContext` from the container, if any.
 
     This function is not recursive, so it will only search at the root level
@@ -192,14 +211,11 @@ def get_container_context(ary: ArrayContainer):
 
 # {{{ object arrays as array containers
 
-@is_array_container.register(np.ndarray)
-def _is_array_container_ndarray(ary: np.ndarray):
-    return ary.dtype.char == "O"
-
-
 @serialize_container.register(np.ndarray)
 def _serialize_ndarray_container(ary: np.ndarray):
-    assert ary.dtype.char == "O"
+    if ary.dtype.char != "O":
+        raise ValueError("arrays that are not of dtype object may not be used as "
+                "array containers")
     return np.ndenumerate(ary)
 
 
@@ -208,6 +224,7 @@ def _deserialize_ndarray_container(
         template: Any, iterable: Iterable[Tuple[Any, Any]]):
     # disallow subclasses
     assert type(template) is np.ndarray
+    assert template.dtype.char == "O"
 
     result = type(template)(template.shape, dtype=object)
     for i, subary in iterable:
@@ -228,7 +245,7 @@ def get_container_context_recursively(ary):
     an assertion error is raised.
     """
     actx = None
-    if not (isinstance(ary, ArrayContainer) or is_array_container(ary)):
+    if not is_array_container(ary):
         return actx
 
     # try getting the array context directly
@@ -437,77 +454,50 @@ def _get_array_container_ac_arith(ary: ArrayContainerWithArithmetic):
 
 # {{{ dataclass containers
 
-# FIXME: Document what this is good for
-class NumpyObjectArray(np.ndarray):
-    pass
+def dataclass_array_container(cls):
+    """A class decorator that makes the class to which it is applied a
+    :class:`ArrayContainer` by registering appropriate implementations of
+    :func:`serialize_container` and :func:`deserialize_container`.
+    *cls* must be a :func:`~dataclasses.dataclass`.
 
-
-class DataclassArrayContainer(ArrayContainer):
-    """An :class:`ArrayContainer` that implements serialization and
-    deserialization of :func:`~dataclasses.dataclass` fields.
+    Attributes that are not array containers are allowed. In order to decide
+    whether an attribute is an array container, the declared attribute type
+    is checked for whether it is a subclass of :class:`ArrayContainer`,
+    using :func:`is_array_container_type`.
     """
+    array_fields = [f for f in fields(cls)
+            if is_array_container_type(f.type)]
+    non_array_fields = [f for f in fields(cls)
+            if not is_array_container_type(f.type)]
 
+    if not array_fields:
+        raise ValueError(f"'{cls}' must have fields with array container type "
+                "in order to use the dataclass_array_container decorator")
 
-class DataclassArrayContainerWithArithmetic(
-        ArrayContainerWithArithmetic,
-        DataclassArrayContainer):
-    """An :class:`DataclassArrayContainer` where each field is assumed to
-    support arithmetic, e.g. through :class:`ArrayContainerWithArithmetic`.
-    """
+    ser_expr = ", ".join(f"({repr(f.name)}, ary.{f.name})" for f in array_fields)
+    template_kwargs = ", ".join(
+            f"{f.name}=template.{f.name}" for f in non_array_fields)
 
-
-@memoize(key=lambda ary: (type(ary), _serialize_dataclass_container))
-def _generate_dataclass_serialization_func(ary):
     from pytools.codegen import remove_common_indentation
-    code = remove_common_indentation("""
-    def _generated_serialize_dataclass(_ary):
-        return [{}]
-    """.format(", ".join(
-        f"('{f.name}', _ary.{f.name})" for f in fields(ary)
-        if issubclass(f.type, (ArrayContainer, NumpyObjectArray))
-        ))
-    )
+    ser_code = remove_common_indentation(f"""
+        from typing import Any, Iterable, Tuple
+        from meshmode.array_context import serialize_container, deserialize_container
 
-    exec_dict = {}
-    exec(compile(code, "<generated code>", "exec"), exec_dict)
-    exec_dict["_MODULE_SOURCE_CODE"] = code
+        @serialize_container.register(cls)
+        def serialize_{cls.__name__.lower()}(ary: cls):
+            return ({ser_expr},)
 
-    return exec_dict["_generated_serialize_dataclass"]
+        @deserialize_container.register(cls)
+        def deserialize_{cls.__name__.lower()}(
+                template: cls, iterable: Iterable[Tuple[Any, Any]]) -> cls:
+            return cls(**dict(iterable), {template_kwargs})
+        """)
 
+    exec_dict = {"cls": cls}
+    exec(compile(ser_code, "<generated code>", "exec"), exec_dict)
+    exec_dict["_MODULE_SOURCE_CODE"] = ser_code
 
-@memoize(key=lambda ary: (type(ary), _deserialize_dataclass_container))
-def _generate_dataclass_deserialization_func(template):
-    from pytools.codegen import remove_common_indentation
-    code = remove_common_indentation("""
-    def _generated_deserialize_dataclass(_template, _iterable):
-        kwargs = dict(_iterable)
-        return type(_template)({})
-    """.format(
-        ", ".join(
-            f"{f.name}=kwargs['{f.name}']"
-            if issubclass(f.type, (ArrayContainer, NumpyObjectArray))
-            else f"{f.name}=_template.{f.name}"
-            for f in fields(template))
-        )
-    )
-
-    exec_dict = {}
-    exec(compile(code, "<generated code>", "exec"), exec_dict)
-    exec_dict["_MODULE_SOURCE_CODE"] = code
-
-    return exec_dict["_generated_deserialize_dataclass"]
-
-
-@serialize_container.register(DataclassArrayContainer)
-def _serialize_dataclass_container(ary: DataclassArrayContainer):
-    return _generate_dataclass_serialization_func(ary)(ary)
-
-
-@deserialize_container.register(DataclassArrayContainer)
-def _deserialize_dataclass_container(
-        template: DataclassArrayContainer,
-        iterable: Iterable[Tuple[Any, Any]]):
-    return _generate_dataclass_deserialization_func(template)(template, iterable)
+    return cls
 
 # }}}
 
@@ -525,7 +515,7 @@ def _map_array_container_impl(f, ary, *, leaf_cls=None, recursive=False):
     def rec(_ary):
         if type(_ary) is leaf_cls:  # type(ary) is never None
             return f(_ary)
-        elif isinstance(_ary, ArrayContainer) or is_array_container(_ary):
+        elif is_array_container(_ary):
             return deserialize_container(_ary, [
                     (key, frec(subary)) for key, subary in serialize_container(_ary)
                     ])
@@ -553,8 +543,7 @@ def _multimap_array_container_impl(f, *args, leaf_cls=None, recursive=False):
                 "expected type '{type(template_ary).__name__}'"
 
         if (type(template_ary) is leaf_cls
-                or not (isinstance(template_ary, ArrayContainer)
-                    or is_array_container(template_ary))):
+                or not is_array_container(template_ary)):
             return f(*_args)
 
         result = []
@@ -578,9 +567,7 @@ def _multimap_array_container_impl(f, *args, leaf_cls=None, recursive=False):
 
     container_indices = [
             i for i, arg in enumerate(args)
-            if (isinstance(arg, ArrayContainer) or is_array_container(arg))
-            and type(arg) is not leaf_cls
-            ]
+            if is_array_container(arg) and type(arg) is not leaf_cls]
 
     if not container_indices:
         return f(*args)
@@ -681,7 +668,7 @@ def freeze(ary, actx=None):
 
     See :meth:`ArrayContext.thaw`.
     """
-    if isinstance(ary, ArrayContainer) or is_array_container(ary):
+    if is_array_container(ary):
         return _map_array_container_impl(
                 partial(freeze, actx=actx), ary,
                 recursive=False)
@@ -706,7 +693,7 @@ def thaw_impl(ary, actx):
         :func:`functools.singledispatch` requires the 'dispatching' argument
         to come first.
     """
-    if isinstance(ary, ArrayContainer) or is_array_container(ary):
+    if is_array_container(ary):
         return deserialize_container(ary, [
             (key, thaw_impl(subary, actx))
             for key, subary in serialize_container(ary)
@@ -844,7 +831,7 @@ class _BaseFakeNumpyNamespace:
             # e.g. `np.zeros_like(x)` returns `array([0, 0, ...], dtype=object)`
             # FIXME: what about object arrays nested in an ArrayContainer?
             raise NotImplementedError("operation not implemented for object arrays")
-        elif isinstance(ary, ArrayContainer) or is_array_container(ary):
+        elif is_array_container(ary):
             return rec_map_array_container(alloc_like, ary)
         elif isinstance(ary, Number):
             # NOTE: `np.zeros_like(x)` returns `array(x, shape=())`, which
@@ -1206,7 +1193,7 @@ class _PyOpenCLFakeNumpyLinalgNamespace(_BaseFakeNumpyLinalgNamespace):
         if ord is None:
             ord = 2
 
-        if isinstance(ary, ArrayContainer) or is_array_container(ary):
+        if is_array_container(ary):
             import numpy.linalg as la
             return la.norm([
                 self.norm(_flatten_array(subary), ord=ord)

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -305,11 +305,11 @@ class ArrayContainerWithArithmetic(ArrayContainer):
         """An :class:`~meshmode.array_context.ArrayContext`."""
 
     @classmethod
-    def unary_op(cls, op, arg):
+    def _unary_op(cls, op, arg):
         return map_array_container(op, arg)
 
     @classmethod
-    def binary_op(cls, op, arg1, arg2):
+    def _binary_op(cls, op, arg1, arg2):
         from numbers import Number
         from pytools.obj_array import obj_array_vectorize
 
@@ -318,11 +318,11 @@ class ArrayContainerWithArithmetic(ArrayContainer):
             # do a bit of broadcasting
             if is_arg1_ndarray:
                 return obj_array_vectorize(
-                        lambda subary: cls.binary_op(op, subary, arg2),
+                        lambda subary: cls._binary_op(op, subary, arg2),
                         arg1.astype(object, copy=False))
             else:
                 return obj_array_vectorize(
-                        lambda subary: cls.binary_op(op, arg1, subary),
+                        lambda subary: cls._binary_op(op, arg1, subary),
                         arg2.astype(object, copy=False))
         elif (isinstance(arg1, ArrayContainer) and isinstance(arg2, ArrayContainer)
                 and type(arg1) is type(arg2)):
@@ -341,99 +341,99 @@ class ArrayContainerWithArithmetic(ArrayContainer):
     # {{{ arithmetic
 
     def __add__(self, arg):
-        return self.binary_op(operator.add, self, arg)
+        return self._binary_op(operator.add, self, arg)
 
     def __sub__(self, arg):
-        return self.binary_op(operator.sub, self, arg)
+        return self._binary_op(operator.sub, self, arg)
 
     def __mul__(self, arg):
-        return self.binary_op(operator.mul, self, arg)
+        return self._binary_op(operator.mul, self, arg)
 
     def __truediv__(self, arg):
-        return self.binary_op(operator.truediv, self, arg)
+        return self._binary_op(operator.truediv, self, arg)
 
     def __pow__(self, arg):
-        return self.binary_op(operator.pow, self, arg)
+        return self._binary_op(operator.pow, self, arg)
 
     def __mod__(self, arg):
-        return self.binary_op(operator.mod, self, arg)
+        return self._binary_op(operator.mod, self, arg)
 
     def __divmod__(self, arg):
-        return self.binary_op(divmod, self, arg)
+        return self._binary_op(divmod, self, arg)
 
     def __radd__(self, arg):
-        return self.binary_op(operator.add, arg, self)
+        return self._binary_op(operator.add, arg, self)
 
     def __rsub__(self, arg):
-        return self.binary_op(operator.sub, arg, self)
+        return self._binary_op(operator.sub, arg, self)
 
     def __rmul__(self, arg):
-        return self.binary_op(operator.mul, arg, self)
+        return self._binary_op(operator.mul, arg, self)
 
     def __rtruediv__(self, arg):
-        return self.binary_op(operator.truediv, arg, self)
+        return self._binary_op(operator.truediv, arg, self)
 
     def __rpow__(self, arg):
-        return self.binary_op(operator.pow, arg, self)
+        return self._binary_op(operator.pow, arg, self)
 
     def __rmod__(self, arg):
-        return self.binary_op(operator.mod, arg, self)
+        return self._binary_op(operator.mod, arg, self)
 
     def __rdivmod__(self, arg):
-        return self.binary_op(divmod, arg, self)
+        return self._binary_op(divmod, arg, self)
 
     def __pos__(self):
         return self
 
     def __neg__(self):
-        return self.unary_op(operator.neg, self)
+        return self._unary_op(operator.neg, self)
 
     def __abs__(self):
-        return self.unary_op(operator.abs, self)
+        return self._unary_op(operator.abs, self)
 
     # }}}
 
     # {{{ comparison
 
     def __eq__(self, arg):
-        return self.binary_op(self.array_context.np.equal, self, arg)
+        return self._binary_op(self.array_context.np.equal, self, arg)
 
     def __ne__(self, arg):
-        return self.binary_op(self.array_context.np.not_equal, self, arg)
+        return self._binary_op(self.array_context.np.not_equal, self, arg)
 
     def __lt__(self, arg):
-        return self.binary_op(self.array_context.np.less, self, arg)
+        return self._binary_op(self.array_context.np.less, self, arg)
 
     def __gt__(self, arg):
-        return self.binary_op(self.array_context.np.greater, self, arg)
+        return self._binary_op(self.array_context.np.greater, self, arg)
 
     def __le__(self, arg):
-        return self.binary_op(self.array_context.np.less_equal, self, arg)
+        return self._binary_op(self.array_context.np.less_equal, self, arg)
 
     def __ge__(self, arg):
-        return self.binary_op(self.array_context.np.greater_equal, self, arg)
+        return self._binary_op(self.array_context.np.greater_equal, self, arg)
 
     # }}}
 
     # {{{ logical
 
     def __and__(self, arg):
-        return self.binary_op(operator.and_, self, arg)
+        return self._binary_op(operator.and_, self, arg)
 
     def __xor__(self, arg):
-        return self.binary_op(operator.xor, self, arg)
+        return self._binary_op(operator.xor, self, arg)
 
     def __or__(self, arg):
-        return self.binary_op(operator.or_, self, arg)
+        return self._binary_op(operator.or_, self, arg)
 
     def __rand__(self, arg):
-        return self.binary_op(operator.and_, arg, self)
+        return self._binary_op(operator.and_, arg, self)
 
     def __rxor__(self, arg):
-        return self.binary_op(operator.xor, arg, self)
+        return self._binary_op(operator.xor, arg, self)
 
     def __ror__(self, arg):
-        return self.binary_op(operator.or_, arg, self)
+        return self._binary_op(operator.or_, arg, self)
 
     # }}}
 

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -198,13 +198,13 @@ def _is_array_container_ndarray(ary: np.ndarray):
 
 
 @serialize_container.register(np.ndarray)
-def _serialize_container_ndarray(ary: np.ndarray):
+def _serialize_ndarray_container(ary: np.ndarray):
     assert ary.dtype.char == "O"
     return np.ndenumerate(ary)
 
 
 @deserialize_container.register(np.ndarray)
-def _deserialize_container_ndarray(
+def _deserialize_ndarray_container(
         template: Any, iterable: Iterable[Tuple[Any, Any]]):
     # disallow subclasses
     assert type(template) is np.ndarray
@@ -457,7 +457,7 @@ class DataclassArrayContainerWithArithmetic(
 
 
 @serialize_container.register(DataclassArrayContainer)
-def _(ary: DataclassArrayContainer):
+def _serialize_dataclass_container(ary: DataclassArrayContainer):
     # FIXME: These field lists could be generated statically.
     z = [(fld.name, getattr(ary, fld.name))
             for fld in fields(ary)
@@ -466,7 +466,9 @@ def _(ary: DataclassArrayContainer):
 
 
 @deserialize_container.register(DataclassArrayContainer)
-def _(template: DataclassArrayContainer, iterable: Iterable[Tuple[Any, Any]]):
+def _deserialize_dataclass_container(
+        template: DataclassArrayContainer,
+        iterable: Iterable[Tuple[Any, Any]]):
     kwargs = dict(iterable)
     # FIXME: These field lists could be generated statically.
     for fld in fields(template):

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -48,8 +48,8 @@ __doc__ = """
 .. autofunction:: get_container_context_recursively
 
 .. autoclass:: ArrayContainerWithArithmetic
-.. autoclass:: DataclassContainer
-.. autoclass:: DataclassContainerWithArithmetic
+.. autoclass:: DataclassArrayContainer
+.. autoclass:: DataclassArrayContainerWithArithmetic
 .. autofunction:: array_container_vectorize
 .. autofunction:: array_container_vectorize_n_args
 .. autofunction:: map_array_container
@@ -412,26 +412,26 @@ def _(ary: ArrayContainerWithArithmetic):
 
 # {{{ dataclass containers
 
-class DataclassContainer(ArrayContainer):
+class DataclassArrayContainer(ArrayContainer):
     """An :class:`ArrayContainer` that implements serialization and
     deserialization of :func:`~dataclasses.dataclass` fields.
     """
 
 
-class DataclassContainerWithArithmetic(
+class DataclassArrayContainerWithArithmetic(
         ArrayContainerWithArithmetic,
-        DataclassContainer):
-    """An :class:`DataclassContainer` where each field is assumed to
+        DataclassArrayContainer):
+    """An :class:`DataclassArrayContainer` where each field is assumed to
     support arithmetic, e.g. through :class:`ArrayContainerWithArithmetic`.
     """
 
 
-@serialize_container.register(DataclassContainer)
-def _(ary: DataclassContainer):
+@serialize_container.register(DataclassArrayContainer)
+def _(ary: DataclassArrayContainer):
     return ((var.name, getattr(ary, var.name)) for var in fields(ary))
 
 
-@deserialize_container_class.register(DataclassContainer)
+@deserialize_container_class.register(DataclassArrayContainer)
 def _(cls, actx, iterable):
     return cls(**dict(iterable))
 
@@ -567,7 +567,7 @@ def map_array_container(f: Callable[[Any], Any], ary):
     return _map_array_container_with_context(f, ary)
 
 
-def mapped_array_container(f: Callable[[Any], Any]):
+def mapped_over_array_containers(f: Callable[[Any], Any]):
     """Decorator around :func:`map_array_container`."""
     wrapper = partial(map_array_container, f)
     update_wrapper(wrapper, f)
@@ -585,7 +585,7 @@ def multimap_array_container(f: Callable[[Any], Any], *args):
     return _multimap_array_container_with_context(f, *args)
 
 
-def multimapped_array_container(f: Callable[[Any], Any]):
+def multimapped_over_array_containers(f: Callable[[Any], Any]):
     """Decorator around :func:`multimap_array_container`."""
     def wrapper(*args):
         return multimap_array_container(f, *args)
@@ -733,7 +733,7 @@ class _BaseFakeNumpyNamespace:
 
         # limit which functions we try to hand off to loopy
         if name in self._numpy_math_functions:
-            return multimapped_array_container(loopy_implemented_elwise_func)
+            return multimapped_over_array_containers(loopy_implemented_elwise_func)
         else:
             raise AttributeError(name)
 

--- a/meshmode/discretization/connection/chained.py
+++ b/meshmode/discretization/connection/chained.py
@@ -23,7 +23,6 @@ THE SOFTWARE.
 import numpy as np
 
 from pytools import Record
-from pytools.obj_array import obj_array_vectorized_n_args
 
 import modepy as mp
 from meshmode.discretization.connection.direct import \
@@ -62,7 +61,6 @@ class ChainedDiscretizationConnection(DiscretizationConnection):
 
         self.connections = connections
 
-    @obj_array_vectorized_n_args
     def __call__(self, ary):
         for cnx in self.connections:
             ary = cnx(ary)

--- a/meshmode/discretization/connection/direct.py
+++ b/meshmode/discretization/connection/direct.py
@@ -25,8 +25,9 @@ import numpy as np
 
 import loopy as lp
 from pytools import memoize_in, keyed_memoize_method
-from meshmode.array_context import ArrayContext, make_loopy_program
-from meshmode.dof_array import multimapped_over_dof_arrays
+from meshmode.array_context import (
+        ArrayContext, make_loopy_program,
+        is_array_container, array_container_vectorize)
 
 
 # {{{ interpolation batch
@@ -268,9 +269,11 @@ class DirectDiscretizationConnection(DiscretizationConnection):
 
         return make_direct_full_resample_matrix(actx, self)
 
-    @multimapped_over_dof_arrays
     def __call__(self, ary):
         from meshmode.dof_array import DOFArray
+        if is_array_container(ary) and not isinstance(ary, DOFArray):
+            return array_container_vectorize(self, ary)
+
         if not isinstance(ary, DOFArray):
             raise TypeError("non-array passed to discretization connection")
 

--- a/meshmode/discretization/connection/direct.py
+++ b/meshmode/discretization/connection/direct.py
@@ -27,7 +27,7 @@ import loopy as lp
 from pytools import memoize_in, keyed_memoize_method
 from meshmode.array_context import (
         ArrayContext, make_loopy_program,
-        is_array_container, array_container_vectorize)
+        is_array_container, map_array_container)
 
 
 # {{{ interpolation batch
@@ -272,7 +272,7 @@ class DirectDiscretizationConnection(DiscretizationConnection):
     def __call__(self, ary):
         from meshmode.dof_array import DOFArray
         if is_array_container(ary) and not isinstance(ary, DOFArray):
-            return array_container_vectorize(self, ary)
+            return map_array_container(self, ary)
 
         if not isinstance(ary, DOFArray):
             raise TypeError("non-array passed to discretization connection")

--- a/meshmode/discretization/connection/direct.py
+++ b/meshmode/discretization/connection/direct.py
@@ -25,8 +25,8 @@ import numpy as np
 
 import loopy as lp
 from pytools import memoize_in, keyed_memoize_method
-from pytools.obj_array import obj_array_vectorized_n_args
 from meshmode.array_context import ArrayContext, make_loopy_program
+from meshmode.dof_array import multimapped_over_dof_arrays
 
 
 # {{{ interpolation batch
@@ -268,7 +268,7 @@ class DirectDiscretizationConnection(DiscretizationConnection):
 
         return make_direct_full_resample_matrix(actx, self)
 
-    @obj_array_vectorized_n_args
+    @multimapped_over_dof_arrays
     def __call__(self, ary):
         from meshmode.dof_array import DOFArray
         if not isinstance(ary, DOFArray):

--- a/meshmode/discretization/connection/modal.py
+++ b/meshmode/discretization/connection/modal.py
@@ -28,7 +28,7 @@ import numpy.linalg as la
 import modepy as mp
 
 from meshmode.array_context import (
-        make_loopy_program, is_array_container, array_container_vectorize)
+        make_loopy_program, is_array_container, map_array_container)
 from meshmode.discretization import InterpolatoryElementGroupBase
 from meshmode.discretization.poly_element import QuadratureSimplexElementGroup
 from meshmode.discretization.connection.direct import DiscretizationConnection
@@ -206,7 +206,7 @@ class NodalToModalDiscretizationConnection(DiscretizationConnection):
         """
         from meshmode.dof_array import DOFArray
         if is_array_container(ary) and not isinstance(ary, DOFArray):
-            return array_container_vectorize(self, ary)
+            return map_array_container(self, ary)
 
         if not isinstance(ary, DOFArray):
             raise TypeError("Non-array passed to discretization connection")
@@ -327,7 +327,7 @@ class ModalToNodalDiscretizationConnection(DiscretizationConnection):
         """
         from meshmode.dof_array import DOFArray
         if is_array_container(ary) and not isinstance(ary, DOFArray):
-            return array_container_vectorize(self, ary)
+            return map_array_container(self, ary)
 
         if not isinstance(ary, DOFArray):
             raise TypeError("Non-array passed to discretization connection")

--- a/meshmode/discretization/connection/modal.py
+++ b/meshmode/discretization/connection/modal.py
@@ -34,7 +34,7 @@ from meshmode.discretization.poly_element import QuadratureSimplexElementGroup
 from meshmode.discretization.connection.direct import DiscretizationConnection
 
 from pytools import memoize_in, keyed_memoize_in
-from pytools.obj_array import obj_array_vectorized_n_args
+from meshmode.dof_array import multimapped_over_dof_arrays
 
 
 class NodalToModalDiscretizationConnection(DiscretizationConnection):
@@ -198,7 +198,7 @@ class NodalToModalDiscretizationConnection(DiscretizationConnection):
 
         return output
 
-    @obj_array_vectorized_n_args
+    @multimapped_over_dof_arrays
     def __call__(self, ary):
         """Computes modal coefficients data from a functions
         nodal coefficients.
@@ -318,7 +318,7 @@ class ModalToNodalDiscretizationConnection(DiscretizationConnection):
                 to_discr=to_discr,
                 is_surjective=True)
 
-    @obj_array_vectorized_n_args
+    @multimapped_over_dof_arrays
     def __call__(self, ary):
         """Computes nodal coefficients from modal data.
 

--- a/meshmode/discretization/connection/projection.py
+++ b/meshmode/discretization/connection/projection.py
@@ -23,12 +23,11 @@ THE SOFTWARE.
 import numpy as np
 
 from pytools import keyed_memoize_method, memoize_in
-from pytools.obj_array import obj_array_vectorized_n_args
 
 import loopy as lp
 
 from meshmode.array_context import make_loopy_program
-from meshmode.dof_array import DOFArray
+from meshmode.dof_array import DOFArray, multimapped_over_dof_arrays
 from meshmode.discretization.connection.direct import (
         DiscretizationConnection,
         DirectDiscretizationConnection)
@@ -118,7 +117,7 @@ class L2ProjectionInverseDiscretizationConnection(DiscretizationConnection):
 
         return weights
 
-    @obj_array_vectorized_n_args
+    @multimapped_over_dof_arrays
     def __call__(self, ary):
         if not isinstance(ary, DOFArray):
             raise TypeError("non-array passed to discretization connection")

--- a/meshmode/discretization/connection/projection.py
+++ b/meshmode/discretization/connection/projection.py
@@ -27,7 +27,7 @@ from pytools import keyed_memoize_method, memoize_in
 import loopy as lp
 
 from meshmode.array_context import (
-        make_loopy_program, is_array_container, array_container_vectorize)
+        make_loopy_program, is_array_container, map_array_container)
 from meshmode.discretization.connection.direct import (
         DiscretizationConnection,
         DirectDiscretizationConnection)
@@ -120,7 +120,7 @@ class L2ProjectionInverseDiscretizationConnection(DiscretizationConnection):
     def __call__(self, ary):
         from meshmode.dof_array import DOFArray
         if is_array_container(ary) and not isinstance(ary, DOFArray):
-            return array_container_vectorize(self, ary)
+            return map_array_container(self, ary)
 
         if not isinstance(ary, DOFArray):
             raise TypeError("non-array passed to discretization connection")

--- a/meshmode/discretization/connection/projection.py
+++ b/meshmode/discretization/connection/projection.py
@@ -26,8 +26,8 @@ from pytools import keyed_memoize_method, memoize_in
 
 import loopy as lp
 
-from meshmode.array_context import make_loopy_program
-from meshmode.dof_array import DOFArray, multimapped_over_dof_arrays
+from meshmode.array_context import (
+        make_loopy_program, is_array_container, array_container_vectorize)
 from meshmode.discretization.connection.direct import (
         DiscretizationConnection,
         DirectDiscretizationConnection)
@@ -117,8 +117,11 @@ class L2ProjectionInverseDiscretizationConnection(DiscretizationConnection):
 
         return weights
 
-    @multimapped_over_dof_arrays
     def __call__(self, ary):
+        from meshmode.dof_array import DOFArray
+        if is_array_container(ary) and not isinstance(ary, DOFArray):
+            return array_container_vectorize(self, ary)
+
         if not isinstance(ary, DOFArray):
             raise TypeError("non-array passed to discretization connection")
 

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -29,7 +29,8 @@ import numpy as np
 
 from pytools import memoize_method, Record
 from pytools.obj_array import make_obj_array
-from meshmode.dof_array import DOFArray, flatten, thaw
+from meshmode.array_context import thaw
+from meshmode.dof_array import DOFArray, flatten
 
 from modepy.shapes import Shape, Simplex, Hypercube
 

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -39,15 +39,15 @@ from meshmode.array_context import (
 from meshmode.array_context import (
         thaw as _thaw, freeze as _freeze,
         map_array_container, multimap_array_container,
-        mapped_array_container, multimapped_array_container)
+        mapped_over_array_containers, multimapped_over_array_containers)
 
 __doc__ = """
 .. autoclass:: DOFArray
 
 .. autofunction:: map_dof_array_container
-.. autofunction:: mapped_dof_array_container
-.. autofunction:: multimap_array_container
-.. autofunction:: multimapped_dof_array_container
+.. autofunction:: mapped_over_dof_arrays
+.. autofunction:: multimap_dof_array_container
+.. autofunction:: multimapped_over_dof_arrays
 
 .. autofunction:: flatten
 .. autofunction:: unflatten
@@ -238,7 +238,7 @@ class DOFArray(ArrayContainerWithArithmetic):
 
         return self
 
-    def __iadd__(self, arg): return self._ibop(op.iadd, arg)             # noqa: E704
+    def __iadd__(self, arg): return self._ibop(op.iadd, arg)            # noqa: E704
     def __isub__(self, arg): return self._ibop(op.isub, arg)            # noqa: E704
     def __imul__(self, arg): return self._ibop(op.imul, arg)            # noqa: E704
     def __itruediv__(self, arg): return self._ibop(op.itruediv, arg)    # noqa: E704
@@ -319,7 +319,7 @@ def map_dof_array_container(f: Callable[[Any], Any], ary):
     return _map_array_container_with_context(f, ary, scalar_cls=DOFArray)
 
 
-def mapped_dof_array_container(f):
+def mapped_over_dof_arrays(f):
     wrapper = partial(map_dof_array_container, f)
     update_wrapper(wrapper, f)
     return wrapper
@@ -336,7 +336,7 @@ def multimap_dof_array_container(f: Callable[[Any], Any], *args):
     return _multimap_array_container_with_context(f, *args, scalar_cls=DOFArray)
 
 
-def multimapped_dof_array_container(f):
+def multimapped_over_dof_arrays(f):
     def wrapper(*args):
         return multimap_dof_array_container(f, *args)
 
@@ -490,14 +490,14 @@ def flat_norm(ary: DOFArray, ord=None):
     return ary.array_context.np.linalg.norm(ary, ord=ord)
 
 
-obj_or_dof_array_vectorize = \
-        MovedFunctionDeprecationWrapper(map_array_container, deadline="2022")
-obj_or_dof_array_vectorized = \
-        MovedFunctionDeprecationWrapper(mapped_array_container, deadline="2022")
-obj_or_dof_array_vectorize_n_args = \
-        MovedFunctionDeprecationWrapper(multimap_array_container, deadline="2022")
-obj_or_dof_array_vectorized_n_args = \
-        MovedFunctionDeprecationWrapper(multimapped_array_container, deadline="2022")
+obj_or_dof_array_vectorize = MovedFunctionDeprecationWrapper(
+        map_array_container, deadline="2022")
+obj_or_dof_array_vectorized = MovedFunctionDeprecationWrapper(
+        mapped_over_array_containers, deadline="2022")
+obj_or_dof_array_vectorize_n_args = MovedFunctionDeprecationWrapper(
+        multimap_array_container, deadline="2022")
+obj_or_dof_array_vectorized_n_args = MovedFunctionDeprecationWrapper(
+        multimapped_over_array_containers, deadline="2022")
 
 thaw = MovedFunctionDeprecationWrapper(_thaw, deadline="2022")
 freeze = MovedFunctionDeprecationWrapper(_freeze, deadline="2022")

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -295,7 +295,9 @@ def _(ary: DOFArray):
 
 
 @deserialize_container_class.register(DOFArray)
-def _(cls, actx: ArrayContext, iterable):
+def _(cls, iterable: Iterable[Tuple[Any, Any]], *,
+        actx: Optional[ArrayContext] = None,
+        template: Optional[Any] = None):
     iterable = list(iterable)
     result = [None] * len(iterable)
 

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -44,6 +44,11 @@ from meshmode.array_context import (
 __doc__ = """
 .. autoclass:: DOFArray
 
+.. autofunction:: map_dof_array_container
+.. autofunction:: mapped_dof_array_container
+.. autofunction:: multimap_array_container
+.. autofunction:: multimapped_dof_array_container
+
 .. autofunction:: flatten
 .. autofunction:: unflatten
 
@@ -304,7 +309,8 @@ def _(cls, actx: ArrayContext, iterable):
 
 
 def map_dof_array_container(f: Callable[[Any], Any], ary):
-    r"""Applies *f* recursively to an :class:`~meshmode.array_context.ArrayContainer`.
+    r"""Applies *f* recursively to an
+    :class:`~meshmode.array_context.ArrayContainer`.
 
     Similar to :func:`~meshmode.array_context.map_array_container`, but
     does not further recurse on :class:`DOFArray`\ s.

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -62,7 +62,7 @@ __doc__ = """
         bcast_obj_array=True,
         bcast_numpy_array=True,
         rel_comparison=True)
-class DOFArray(ArrayContainer):
+class DOFArray:
     r"""This array type holds degree-of-freedom arrays for use with
     :class:`~meshmode.discretization.Discretization`,
     with one entry in the :class:`DOFArray` for each

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -294,12 +294,12 @@ class _EntryNotProvided:
 
 
 @serialize_container.register(DOFArray)
-def _serialize_container_dofarray(ary: DOFArray):
+def _serialize_dof_container(ary: DOFArray):
     return enumerate(ary._data)
 
 
 @deserialize_container.register(DOFArray)
-def _deserialize_container_dofarray(
+def _deserialize_dof_container(
         template: Any, iterable: Iterable[Tuple[Any, Any]]):
     def _raise_index_inconsistency(i, stream_i):
         raise ValueError(

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -289,6 +289,10 @@ class DOFArray(ArrayContainerWithArithmetic):
 
 # {{{ ArrayContainer implementation
 
+class _EntryNotProvided:
+    pass
+
+
 @serialize_container.register(DOFArray)
 def _(ary: DOFArray):
     return enumerate(ary._data)
@@ -298,12 +302,12 @@ def _(ary: DOFArray):
 def _(cls, template: Any, iterable: Iterable[Tuple[Any, Any]], *,
         actx: Optional[ArrayContext] = None):
     iterable = list(iterable)
-    result = [None] * len(iterable)
+    result = [_EntryNotProvided] * len(iterable)
 
     for i, subary in iterable:
         result[i] = subary
 
-    if any(subary is None for subary in result):
+    if any(subary is _EntryNotProvided for subary in result):
         raise ValueError("'iterable' does not contain all indices")
 
     return cls(actx, data=tuple(result))

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -309,8 +309,8 @@ def map_dof_array_container(f: Callable[[Any], Any], ary):
     Similar to :func:`~meshmode.array_context.map_array_container`, but
     does not further recurse on :class:`DOFArray`\ s.
     """
-    from meshmode.array_context import _map_array_container_with_leaf_class
-    return _map_array_container_with_leaf_class(f, ary, leaf_class=DOFArray)
+    from meshmode.array_context import _map_array_container_with_context
+    return _map_array_container_with_context(f, ary, scalar_cls=DOFArray)
 
 
 def mapped_dof_array_container(f):
@@ -326,8 +326,8 @@ def multimap_dof_array_container(f: Callable[[Any], Any], *args):
     Similar to :func:`~meshmode.array_context.multimap_array_container`, but
     does not further recurse on :class:`DOFArray`\ s.
     """
-    from meshmode.array_context import _multimap_array_container_with_leaf_class
-    return _multimap_array_container_with_leaf_class(f, *args, leaf_class=DOFArray)
+    from meshmode.array_context import _multimap_array_container_with_context
+    return _multimap_array_container_with_context(f, *args, scalar_cls=DOFArray)
 
 
 def multimapped_dof_array_container(f):

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -319,7 +319,7 @@ def map_dof_array_container(f: Callable[[Any], Any], ary):
     """
     from meshmode.array_context import _map_array_container_with_context
     return _map_array_container_with_context(
-            f, ary, scalar_cls=DOFArray, recursive=True)
+            f, ary, leaf_cls=DOFArray, recursive=True)
 
 
 def mapped_over_dof_arrays(f):
@@ -337,7 +337,7 @@ def multimap_dof_array_container(f: Callable[[Any], Any], *args):
     """
     from meshmode.array_context import _multimap_array_container_with_context
     return _multimap_array_container_with_context(
-            f, *args, scalar_cls=DOFArray, recursive=True)
+            f, *args, leaf_cls=DOFArray, recursive=True)
 
 
 def multimapped_over_dof_arrays(f):

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -318,7 +318,8 @@ def map_dof_array_container(f: Callable[[Any], Any], ary):
     does not further recurse on :class:`DOFArray`\ s.
     """
     from meshmode.array_context import _map_array_container_with_context
-    return _map_array_container_with_context(f, ary, scalar_cls=DOFArray)
+    return _map_array_container_with_context(
+            f, ary, scalar_cls=DOFArray, recursive=True)
 
 
 def mapped_over_dof_arrays(f):
@@ -335,7 +336,8 @@ def multimap_dof_array_container(f: Callable[[Any], Any], *args):
     does not further recurse on :class:`DOFArray`\ s.
     """
     from meshmode.array_context import _multimap_array_container_with_context
-    return _multimap_array_container_with_context(f, *args, scalar_cls=DOFArray)
+    return _multimap_array_container_with_context(
+            f, *args, scalar_cls=DOFArray, recursive=True)
 
 
 def multimapped_over_dof_arrays(f):

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -358,7 +358,7 @@ def flatten(ary: ArrayContainer) -> Any:
     def _flatten_dof_array(subary):
         actx = subary.array_context
         if actx is None:
-            raise ValueError("cannot flatten frozen ArrayContainers")
+            raise ValueError("cannot flatten frozen DOFArrays")
 
         @memoize_in(actx, (flatten, "flatten_prg"))
         def prg():

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -44,9 +44,9 @@ from meshmode.array_context import (
 __doc__ = """
 .. autoclass:: DOFArray
 
-.. autofunction:: map_dof_array_container
+.. autofunction:: rec_map_dof_array_container
 .. autofunction:: mapped_over_dof_arrays
-.. autofunction:: multimap_dof_array_container
+.. autofunction:: rec_multimap_dof_array_container
 .. autofunction:: multimapped_over_dof_arrays
 
 .. autofunction:: flatten

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -289,10 +289,6 @@ class DOFArray(ArrayContainerWithArithmetic):
 
 # {{{ ArrayContainer implementation
 
-class _EntryNotProvided:
-    pass
-
-
 @serialize_container.register(DOFArray)
 def _serialize_dof_container(ary: DOFArray):
     return enumerate(ary._data)

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -38,7 +38,7 @@ from meshmode.array_context import (
         serialize_container, deserialize_container)
 from meshmode.array_context import (
         thaw as _thaw, thaw_impl, freeze as _freeze,
-        map_array_container, multimap_array_container,
+        rec_map_array_container, rec_multimap_array_container,
         mapped_over_array_containers, multimapped_over_array_containers)
 
 __doc__ = """
@@ -334,38 +334,38 @@ def _thaw_dofarray(ary, actx):
         tuple(actx.thaw(subary) for subary in ary._data))
 
 
-def map_dof_array_container(f: Callable[[Any], Any], ary):
+def rec_map_dof_array_container(f: Callable[[Any], Any], ary):
     r"""Applies *f* recursively to an
     :class:`~meshmode.array_context.ArrayContainer`.
 
     Similar to :func:`~meshmode.array_context.map_array_container`, but
     does not further recurse on :class:`DOFArray`\ s.
     """
-    from meshmode.array_context import _map_array_container
-    return _map_array_container(f, ary, leaf_cls=DOFArray, recursive=True)
+    from meshmode.array_context import _map_array_container_impl
+    return _map_array_container_impl(f, ary, leaf_cls=DOFArray, recursive=True)
 
 
 def mapped_over_dof_arrays(f):
-    wrapper = partial(map_dof_array_container, f)
+    wrapper = partial(rec_map_dof_array_container, f)
     update_wrapper(wrapper, f)
     return wrapper
 
 
-def multimap_dof_array_container(f: Callable[[Any], Any], *args):
+def rec_multimap_dof_array_container(f: Callable[[Any], Any], *args):
     r"""Applies *f* recursively to multiple
     :class:`~meshmode.array_context.ArrayContainer`\ s.
 
     Similar to :func:`~meshmode.array_context.multimap_array_container`, but
     does not further recurse on :class:`DOFArray`\ s.
     """
-    from meshmode.array_context import _multimap_array_container
-    return _multimap_array_container(
+    from meshmode.array_context import _multimap_array_container_impl
+    return _multimap_array_container_impl(
             f, *args, leaf_cls=DOFArray, recursive=True)
 
 
 def multimapped_over_dof_arrays(f):
     def wrapper(*args):
-        return multimap_dof_array_container(f, *args)
+        return rec_multimap_dof_array_container(f, *args)
 
     update_wrapper(wrapper, f)
     return wrapper
@@ -414,7 +414,7 @@ def flatten(ary: ArrayContainer) -> Any:
 
         return result
 
-    return map_dof_array_container(_flatten_dof_array, ary)
+    return rec_map_dof_array_container(_flatten_dof_array, ary)
 
 
 def _unflatten(
@@ -472,7 +472,7 @@ def unflatten(actx: ArrayContext, discr,
     def _unflatten_dof_array(subary):
         return _unflatten(actx, nel_ndof_per_element_per_group, subary)
 
-    return map_dof_array_container(_unflatten_dof_array, ary)
+    return rec_map_dof_array_container(_unflatten_dof_array, ary)
 
 # }}}
 
@@ -518,11 +518,11 @@ def flat_norm(ary: DOFArray, ord=None):
 
 
 obj_or_dof_array_vectorize = MovedFunctionDeprecationWrapper(
-        map_array_container, deadline="2022")
+        rec_map_array_container, deadline="2022")
 obj_or_dof_array_vectorized = MovedFunctionDeprecationWrapper(
         mapped_over_array_containers, deadline="2022")
 obj_or_dof_array_vectorize_n_args = MovedFunctionDeprecationWrapper(
-        multimap_array_container, deadline="2022")
+        rec_multimap_array_container, deadline="2022")
 obj_or_dof_array_vectorized_n_args = MovedFunctionDeprecationWrapper(
         multimapped_over_array_containers, deadline="2022")
 

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -295,9 +295,8 @@ def _(ary: DOFArray):
 
 
 @deserialize_container_class.register(DOFArray)
-def _(cls, iterable: Iterable[Tuple[Any, Any]], *,
-        actx: Optional[ArrayContext] = None,
-        template: Optional[Any] = None):
+def _(cls, template: Any, iterable: Iterable[Tuple[Any, Any]], *,
+        actx: Optional[ArrayContext] = None):
     iterable = list(iterable)
     result = [None] * len(iterable)
 

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -363,24 +363,24 @@ def test_container_multimap(actx_factory):
     def func_multiple_scalar(a, subary1, b, subary2):
         return a * subary1 + b * subary2
 
-    from meshmode.array_context import multimap_array_container
-    result = multimap_array_container(func_all_scalar, 1, 2)
+    from meshmode.array_context import rec_multimap_array_container
+    result = rec_multimap_array_container(func_all_scalar, 1, 2)
     assert result == 3
 
     from functools import partial
     for ary in [ary_dof, ary_of_dofs, mat_of_dofs, dc_of_dofs]:
-        result = multimap_array_container(func_first_scalar, 1, ary)
-        multimap_array_container(
+        result = rec_multimap_array_container(func_first_scalar, 1, ary)
+        rec_multimap_array_container(
                 partial(_check_allclose, lambda x: 1 + x),
                 ary, result)
 
-        result = multimap_array_container(func_multiple_scalar, 2, ary, 2, ary)
-        multimap_array_container(
+        result = rec_multimap_array_container(func_multiple_scalar, 2, ary, 2, ary)
+        rec_multimap_array_container(
                 partial(_check_allclose, lambda x: 4 * x),
                 ary, result)
 
     with pytest.raises(AssertionError):
-        multimap_array_container(func_multiple_scalar, 2, ary_dof, 2, dc_of_dofs)
+        rec_multimap_array_container(func_multiple_scalar, 2, ary_dof, 2, dc_of_dofs)
 
     # }}}
 
@@ -395,12 +395,12 @@ def test_container_arithmetic(actx_factory):
         assert np.linalg.norm((f(arg1) - arg2).get()) < atol
 
     from functools import partial
-    from meshmode.array_context import multimap_array_container
+    from meshmode.array_context import rec_multimap_array_container
     for ary in [ary_dof, ary_of_dofs, mat_of_dofs, dc_of_dofs]:
-        multimap_array_container(
+        rec_multimap_array_container(
                 partial(_check_allclose, lambda x: 3 * x),
                 ary, 2 * ary + ary)
-        multimap_array_container(
+        rec_multimap_array_container(
                 partial(_check_allclose, lambda x: actx.np.sin(x)),
                 ary, actx.np.sin(ary))
 

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -20,6 +20,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+from dataclasses import dataclass
+
 import pytest
 import numpy as np
 
@@ -27,6 +29,7 @@ import meshmode         # noqa: F401
 from meshmode.array_context import (  # noqa
         pytest_generate_tests_for_pyopencl_array_context
         as pytest_generate_tests)
+from meshmode.array_context import DataclassArrayContainerWithArithmetic
 
 from meshmode.discretization import Discretization
 from meshmode.discretization.poly_element import PolynomialWarpAndBlendGroupFactory
@@ -305,10 +308,18 @@ def test_array_context_einsum_array_tripleprod(actx_factory, spec):
 
 # {{{ test array container
 
-def test_recursive_freeze_thaw(actx_factory):
-    actx = actx_factory()
-    ambient_dim = 2
+@dataclass
+class MyContainer(DataclassArrayContainerWithArithmetic):
+    mass: DOFArray
+    momentum: np.ndarray
+    enthalpy: DOFArray
 
+    @property
+    def array_context(self):
+        return self.mass.array_context
+
+
+def _get_test_containers(actx, ambient_dim=2):
     from meshmode.mesh.generation import generate_regular_rect_mesh
     mesh = generate_regular_rect_mesh(
             a=(-0.5,)*ambient_dim,
@@ -316,32 +327,14 @@ def test_recursive_freeze_thaw(actx_factory):
             n=(3,)*ambient_dim, order=1)
     discr = Discretization(actx, mesh, PolynomialWarpAndBlendGroupFactory(3))
 
-    # {{{ ArrayContainer
-
-    from dataclasses import dataclass
-    from meshmode.array_context import DataclassArrayContainerWithArithmetic
-
-    @dataclass
-    class MyContainer(DataclassArrayContainerWithArithmetic):
-        mass: DOFArray
-        momentum: np.ndarray
-        enthalpy: DOFArray
-
-        @property
-        def array_context(self):
-            return self.mass.array_context
-
-    # }}}
-
-    from meshmode.array_context import thaw, freeze
+    from meshmode.array_context import thaw
     x = thaw(actx, discr.nodes()[0])
 
     # pylint: disable=unexpected-keyword-arg, no-value-for-parameter
-    ary_dataclass = MyContainer(
+    dataclass_of_dofs = MyContainer(
             mass=x,
             momentum=make_obj_array([x, x]),
             enthalpy=x)
-    ary_dataclass = actx.np.sin(ary_dataclass + 3 * ary_dataclass)
 
     ary_dof = x
     ary_of_dofs = make_obj_array([x, x, x])
@@ -349,20 +342,98 @@ def test_recursive_freeze_thaw(actx_factory):
     for i in np.ndindex(mat_of_dofs.shape):
         mat_of_dofs[i] = x
 
-    for ary in [ary_dof, ary_of_dofs, mat_of_dofs, ary_dataclass]:
+    return ary_dof, ary_of_dofs, mat_of_dofs, dataclass_of_dofs
+
+
+def test_container_multimap(actx_factory):
+    actx = actx_factory()
+    ary_dof, ary_of_dofs, mat_of_dofs, dc_of_dofs = _get_test_containers(actx)
+
+    # {{{ check
+
+    def _check_allclose(f, arg1, arg2, atol=1.0e-14):
+        assert np.linalg.norm((f(arg1) - arg2).get()) < atol
+
+    def func_all_scalar(x, y):
+        return x + y
+
+    def func_first_scalar(x, subary):
+        return x + subary
+
+    def func_multiple_scalar(a, subary1, b, subary2):
+        return a * subary1 + b * subary2
+
+    from meshmode.array_context import multimap_array_container
+    result = multimap_array_container(func_all_scalar, 1, 2)
+    assert result == 3
+
+    from functools import partial
+    for ary in [ary_dof, ary_of_dofs, mat_of_dofs, dc_of_dofs]:
+        result = multimap_array_container(func_first_scalar, 1, ary)
+        multimap_array_container(
+                partial(_check_allclose, lambda x: 1 + x),
+                ary, result)
+
+        result = multimap_array_container(func_multiple_scalar, 2, ary, 2, ary)
+        multimap_array_container(
+                partial(_check_allclose, lambda x: 4 * x),
+                ary, result)
+
+    with pytest.raises(TypeError):
+        multimap_array_container(func_multiple_scalar, 2, ary_dof, 2, dc_of_dofs)
+
+    # }}}
+
+
+def test_container_arithmetic(actx_factory):
+    actx = actx_factory()
+    ary_dof, ary_of_dofs, mat_of_dofs, dc_of_dofs = _get_test_containers(actx)
+
+    # {{{ check
+
+    def _check_allclose(f, arg1, arg2, atol=1.0e-14):
+        assert np.linalg.norm((f(arg1) - arg2).get()) < atol
+
+    from functools import partial
+    from meshmode.array_context import multimap_array_container
+    for ary in [ary_dof, ary_of_dofs, mat_of_dofs, dc_of_dofs]:
+        multimap_array_container(
+                partial(_check_allclose, lambda x: 3 * x),
+                ary, 2 * ary + ary)
+        multimap_array_container(
+                partial(_check_allclose, lambda x: actx.np.sin(x)),
+                ary, actx.np.sin(ary))
+
+    # }}}
+
+
+def test_container_freeze_thaw(actx_factory):
+    actx = actx_factory()
+    ary_dof, ary_of_dofs, mat_of_dofs, dc_of_dofs = _get_test_containers(actx)
+
+    # {{{ check
+
+    from meshmode.array_context import get_container_context
+    from meshmode.array_context import get_container_context_recursively
+
+    assert get_container_context(ary_of_dofs) is None
+    assert get_container_context(mat_of_dofs) is None
+    assert get_container_context(ary_dof) is actx
+    assert get_container_context(dc_of_dofs) is actx
+
+    assert get_container_context_recursively(ary_of_dofs) is actx
+    assert get_container_context_recursively(mat_of_dofs) is actx
+
+    from meshmode.array_context import thaw, freeze
+    for ary in [ary_dof, ary_of_dofs, mat_of_dofs, dc_of_dofs]:
         frozen_ary = freeze(ary)
         thawed_ary = thaw(actx, frozen_ary)
         frozen_ary = freeze(thawed_ary)
 
-    from meshmode.array_context import get_container_context
-    assert get_container_context(ary_of_dofs) is None
-    assert get_container_context(mat_of_dofs) is None
-    assert get_container_context(ary_dof) is actx
-    assert get_container_context(ary_dataclass) is actx
+        assert get_container_context_recursively(frozen_ary) is None
+        assert get_container_context_recursively(thawed_ary) is actx
 
-    from meshmode.array_context import get_container_context_recursively
-    assert get_container_context_recursively(ary_of_dofs) is actx
-    assert get_container_context_recursively(mat_of_dofs) is actx
+    # }}}
 
 # }}}
 

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -343,21 +343,26 @@ def test_recursive_freeze_thaw(actx_factory):
             enthalpy=x)
     ary_dataclass = actx.np.sin(ary_dataclass + 3 * ary_dataclass)
 
-    ary_of_dofs = make_obj_array([x, x, x])
     ary_dof = x
+    ary_of_dofs = make_obj_array([x, x, x])
+    mat_of_dofs = np.empty((2, 2), dtype=object)
+    for i in np.ndindex(mat_of_dofs.shape):
+        mat_of_dofs[i] = x
 
-    for ary in [ary_dof, ary_of_dofs, ary_dataclass]:
+    for ary in [ary_dof, ary_of_dofs, mat_of_dofs, ary_dataclass]:
         frozen_ary = freeze(ary)
         thawed_ary = thaw(actx, frozen_ary)
         frozen_ary = freeze(thawed_ary)
 
     from meshmode.array_context import get_container_context
     assert get_container_context(ary_of_dofs) is None
+    assert get_container_context(mat_of_dofs) is None
     assert get_container_context(ary_dof) is actx
     assert get_container_context(ary_dataclass) is actx
 
     from meshmode.array_context import get_container_context_recursively
     assert get_container_context_recursively(ary_of_dofs) is actx
+    assert get_container_context_recursively(mat_of_dofs) is actx
 
 # }}}
 

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -319,10 +319,10 @@ def test_recursive_freeze_thaw(actx_factory):
     # {{{ ArrayContainer
 
     from dataclasses import dataclass
-    from meshmode.array_context import DataclassContainerWithArithmetic
+    from meshmode.array_context import DataclassArrayContainerWithArithmetic
 
     @dataclass
-    class MyContainer(DataclassContainerWithArithmetic):
+    class MyContainer(DataclassArrayContainerWithArithmetic):
         mass: DOFArray
         momentum: np.ndarray
         enthalpy: DOFArray

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -318,13 +318,11 @@ def test_recursive_freeze_thaw(actx_factory):
 
     # {{{ ArrayContainer
 
-    from dataclasses import dataclass, fields
-    from meshmode.array_context import (
-            ArrayContainerWithArithmetic,
-            serialize_container, deserialize_container_class)
+    from dataclasses import dataclass
+    from meshmode.array_context import DataclassContainerWithArithmetic
 
     @dataclass
-    class DataclassArrayContainer(ArrayContainerWithArithmetic):
+    class MyContainer(DataclassContainerWithArithmetic):
         mass: DOFArray
         momentum: np.ndarray
         enthalpy: DOFArray
@@ -333,21 +331,13 @@ def test_recursive_freeze_thaw(actx_factory):
         def array_context(self):
             return self.mass.array_context
 
-    @serialize_container.register(DataclassArrayContainer)
-    def _(ary: DataclassArrayContainer):
-        return ((var.name, getattr(ary, var.name)) for var in fields(ary))
-
-    @deserialize_container_class.register(DataclassArrayContainer)
-    def _(cls, actx, iterable):
-        return DataclassArrayContainer(**dict(iterable))
-
     # }}}
 
     from meshmode.array_context import thaw, freeze
     x = thaw(actx, discr.nodes()[0])
 
     # pylint: disable=unexpected-keyword-arg, no-value-for-parameter
-    ary_dataclass = DataclassArrayContainer(
+    ary_dataclass = MyContainer(
             mass=x,
             momentum=make_obj_array([x, x]),
             enthalpy=x)

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -454,6 +454,23 @@ def test_container_freeze_thaw(actx_factory):
 
     # }}}
 
+
+@pytest.mark.parametrize("ord", [2, np.inf])
+def test_container_norm(actx_factory, ord):
+    actx = actx_factory()
+
+    ary_dof, ary_of_dofs, mat_of_dofs, dc_of_dofs = _get_test_containers(actx)
+
+    from pytools.obj_array import make_obj_array
+    c = MyContainer(name="hey", mass=1, momentum=make_obj_array([2, 3]), enthalpy=5)
+    n1 = actx.np.linalg.norm(make_obj_array([c, c]), ord)
+    n2 = np.linalg.norm([1, 2, 3, 5]*2, ord)
+
+    assert abs(n1 - n2) < 1e-12
+
+    from meshmode.dof_array import flat_norm
+    assert abs(flat_norm(ary_dof, ord) - actx.np.linalg.norm(ary_dof, ord)) < 1e-12
+
 # }}}
 
 

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -310,6 +310,7 @@ def test_array_context_einsum_array_tripleprod(actx_factory, spec):
 
 @dataclass
 class MyContainer(DataclassArrayContainerWithArithmetic):
+    name: str
     mass: DOFArray
     momentum: np.ndarray
     enthalpy: DOFArray
@@ -332,6 +333,7 @@ def _get_test_containers(actx, ambient_dim=2):
 
     # pylint: disable=unexpected-keyword-arg, no-value-for-parameter
     dataclass_of_dofs = MyContainer(
+            name="container",
             mass=x,
             momentum=make_obj_array([x, x]),
             enthalpy=x)

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -379,7 +379,7 @@ def test_container_multimap(actx_factory):
                 partial(_check_allclose, lambda x: 4 * x),
                 ary, result)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AssertionError):
         multimap_array_container(func_multiple_scalar, 2, ary_dof, 2, dc_of_dofs)
 
     # }}}

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -362,7 +362,12 @@ def test_recursive_freeze_thaw(actx_factory):
         frozen_ary = freeze(thawed_ary)
 
     from meshmode.array_context import get_container_context
-    assert actx is get_container_context(ary_of_dofs)
+    assert get_container_context(ary_of_dofs) is None
+    assert get_container_context(ary_dof) is actx
+    assert get_container_context(ary_dataclass) is actx
+
+    from meshmode.array_context import get_container_context_recursively
+    assert get_container_context_recursively(ary_of_dofs) is actx
 
 # }}}
 

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -21,7 +21,6 @@ THE SOFTWARE.
 """
 
 from dataclasses import dataclass
-
 import pytest
 import numpy as np
 
@@ -29,7 +28,9 @@ import meshmode         # noqa: F401
 from meshmode.array_context import (  # noqa
         pytest_generate_tests_for_pyopencl_array_context
         as pytest_generate_tests)
-from meshmode.array_context import DataclassArrayContainerWithArithmetic
+from meshmode.array_context import (
+        dataclass_array_container,
+        ArrayContainerWithArithmetic)
 
 from meshmode.discretization import Discretization
 from meshmode.discretization.poly_element import PolynomialWarpAndBlendGroupFactory
@@ -308,8 +309,9 @@ def test_array_context_einsum_array_tripleprod(actx_factory, spec):
 
 # {{{ test array container
 
-@dataclass
-class MyContainer(DataclassArrayContainerWithArithmetic):
+@dataclass_array_container
+@dataclass(frozen=True)
+class MyContainer(ArrayContainerWithArithmetic):
     name: str
     mass: DOFArray
     momentum: np.ndarray

--- a/test/test_chained.py
+++ b/test/test_chained.py
@@ -27,7 +27,7 @@ from meshmode.array_context import (  # noqa
         pytest_generate_tests_for_pyopencl_array_context
         as pytest_generate_tests)
 
-from meshmode.dof_array import thaw, flatten
+from meshmode.dof_array import thaw, flatten, flat_norm
 
 import logging
 logger = logging.getLogger(__name__)
@@ -213,7 +213,7 @@ def test_chained_connection(actx_factory, ndim, visualize=False):
     f1 = chained(fx)
     f2 = connections[1](connections[0](fx))
 
-    assert actx.np.linalg.norm(f1-f2, np.inf) / actx.np.linalg.norm(f2) < 1e-11
+    assert flat_norm(f1-f2, np.inf) / flat_norm(f2) < 1e-11
 
 
 @pytest.mark.parametrize("ndim", [2, 3])
@@ -380,8 +380,8 @@ def test_reversed_chained_connection(actx_factory, ndim, mesh_name):
         from_interp = reverse(to_x)
 
         return (1.0 / nelements,
-                actx.np.linalg.norm(from_interp - from_x, np.inf)
-                / actx.np.linalg.norm(from_x, np.inf))
+                flat_norm(from_interp - from_x, np.inf)
+                / flat_norm(from_x, np.inf))
 
     from pytools.convergence import EOCRecorder
     eoc = EOCRecorder()

--- a/test/test_interop.py
+++ b/test/test_interop.py
@@ -29,7 +29,7 @@ from meshmode.array_context import (  # noqa
         pytest_generate_tests_for_pyopencl_array_context
         as pytest_generate_tests,
         PyOpenCLArrayContext)
-from meshmode.dof_array import thaw
+from meshmode.dof_array import thaw, flat_norm
 
 import logging
 logger = logging.getLogger(__name__)
@@ -57,7 +57,7 @@ def test_nodal_dg_interop(actx_factory, dim):
 
         for ax in range(dim):
             x_ax = ndgctx.pull_dof_array(actx, ndgctx.AXES[ax])
-            err = actx.np.linalg.norm(x_ax-discr.nodes()[ax], np.inf)
+            err = flat_norm(x_ax-discr.nodes()[ax], np.inf)
             assert err < 1e-15
 
         n0 = thaw(actx, discr.nodes()[0])
@@ -65,7 +65,7 @@ def test_nodal_dg_interop(actx_factory, dim):
         ndgctx.push_dof_array("n0", n0)
         n0_2 = ndgctx.pull_dof_array(actx, "n0")
 
-        assert actx.np.linalg.norm(n0 - n0_2, np.inf) < 1e-15
+        assert flat_norm(n0 - n0_2, np.inf) < 1e-15
 
 
 if __name__ == "__main__":

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -39,7 +39,7 @@ from meshmode.discretization.poly_element import (
         LegendreGaussLobattoTensorProductGroupFactory
         )
 from meshmode.mesh import Mesh, BTAG_ALL
-from meshmode.dof_array import thaw, flatten
+from meshmode.dof_array import thaw, flatten, flat_norm
 from meshmode.discretization.connection import \
         FACE_RESTR_ALL, FACE_RESTR_INTERIOR
 import meshmode.mesh.generation as mgen
@@ -167,7 +167,7 @@ def test_boundary_interpolation(actx_factory, group_factory, boundary_tag,
             mat_error = la.norm(actx.to_numpy(flatten(bdry_f_2)) - bdry_f_2_by_mat)
             assert mat_error < 1e-14, mat_error
 
-        err = actx.np.linalg.norm(bdry_f-bdry_f_2, np.inf)
+        err = flat_norm(bdry_f-bdry_f_2, np.inf)
         eoc_rec.add_data_point(h, err)
 
     order_slack = 0.75 if mesh_name == "blob" else 0.5
@@ -290,7 +290,7 @@ def test_all_faces_interpolation(actx_factory, group_factory,
 
             all_face_f_2 = all_face_f_2 + all_face_embedding(bdry_f)
 
-        err = actx.np.linalg.norm(all_face_f-all_face_f_2, np.inf)
+        err = flat_norm(all_face_f-all_face_f_2, np.inf)
         eoc_rec.add_data_point(h, err)
 
     print(eoc_rec)
@@ -393,7 +393,7 @@ def test_opposite_face_interpolation(actx_factory, group_factory,
         bdry_f = f(bdry_x)
         bdry_f_2 = opp_face(bdry_f)
 
-        err = actx.np.linalg.norm(bdry_f-bdry_f_2, np.inf)
+        err = flat_norm(bdry_f-bdry_f_2, np.inf)
         eoc_rec.add_data_point(h, err)
 
     print(eoc_rec)
@@ -593,8 +593,8 @@ def test_sanity_qhull_nd(actx_factory, dim, order):
     f_high_num = cnx(f_low)
 
     err = (
-            actx.np.linalg.norm(f_high_ref-f_high_num, np.inf)
-            / actx.np.linalg.norm(f_high_ref, np.inf))
+            flat_norm(f_high_ref-f_high_num, np.inf)
+            / flat_norm(f_high_ref, np.inf))
 
     print(err)
     assert err < 1e-2
@@ -819,7 +819,7 @@ def test_mesh_multiple_groups(actx_factory, ambient_dim, visualize=False):
             check_connection(actx, opposite)
 
             op_bdry_f = opposite(bdry_f)
-            error = actx.np.linalg.norm(bdry_f - op_bdry_f, np.inf)
+            error = flat_norm(bdry_f - op_bdry_f, np.inf)
             assert error < 1.0e-11, error
 
         if boundary_tag == FACE_RESTR_ALL:
@@ -827,7 +827,7 @@ def test_mesh_multiple_groups(actx_factory, ambient_dim, visualize=False):
             check_connection(actx, embedding)
 
             em_bdry_f = embedding(bdry_f)
-            error = actx.np.linalg.norm(bdry_f - em_bdry_f)
+            error = flat_norm(bdry_f - em_bdry_f)
             assert error < 1.0e-11, error
 
     # check some derivatives (nb: flatten is a generator)

--- a/test/test_modal.py
+++ b/test/test_modal.py
@@ -29,7 +29,7 @@ from meshmode.array_context import (  # noqa
     pytest_generate_tests_for_pyopencl_array_context
     as pytest_generate_tests
     )
-from meshmode.dof_array import DOFArray
+from meshmode.dof_array import DOFArray, flat_norm
 from meshmode.mesh import (
     SimplexElementGroup,
     TensorProductElementGroup
@@ -110,7 +110,7 @@ def test_inverse_modal_connections(actx_factory, nodal_group_factory):
 
     # This error should be small since we composed a map with
     # its inverse
-    err = actx.np.linalg.norm(nodal_f - nodal_f_2)
+    err = flat_norm(nodal_f - nodal_f_2)
 
     assert err <= 1e-13
 
@@ -170,7 +170,7 @@ def test_modal_coefficients_by_projection(actx_factory, quad_group_factory):
     # Map nodal coefficients using the quadrature-based projection
     modal_f_computed = nodal_to_modal_conn_quad(nodal_f)
 
-    err = actx.np.linalg.norm(modal_f_expected - modal_f_computed)
+    err = flat_norm(modal_f_expected - modal_f_computed)
 
     assert err <= 1e-13
 
@@ -217,7 +217,7 @@ def test_quadrature_based_modal_connection_reverse(actx_factory, quad_group_fact
     # Back to nodal
     nodal_f_computed = modal_to_nodal_conn(modal_f_quad)
 
-    err = actx.np.linalg.norm(nodal_f - nodal_f_computed)
+    err = flat_norm(nodal_f - nodal_f_computed)
 
     assert err <= 1e-11
 
@@ -302,7 +302,7 @@ def test_modal_truncation(actx_factory, nodal_group_factory,
         # Now map truncated modal coefficients back to nodal
         nodal_f_truncated = modal_to_nodal_conn(modal_f_truncated)
 
-        err = actx.np.linalg.norm(nodal_f - nodal_f_truncated)
+        err = flat_norm(nodal_f - nodal_f_truncated)
         eoc_rec.add_data_point(h, err)
         threshold_lower = 0.8*truncated_order
         threshold_upper = 1.2*truncated_order

--- a/test/test_partition.py
+++ b/test/test_partition.py
@@ -26,7 +26,7 @@ THE SOFTWARE.
 import numpy as np
 import pyopencl as cl
 
-from meshmode.dof_array import thaw, flatten, unflatten
+from meshmode.dof_array import thaw, flatten, unflatten, flat_norm
 
 from meshmode.array_context import (  # noqa
         pytest_generate_tests_for_pyopencl_array_context
@@ -159,7 +159,7 @@ def test_partition_interpolation(actx_factory, dim, mesh_pars,
             remote_points = local_to_remote_conn(true_local_points)
             local_points = remote_to_local_conn(remote_points)
 
-            err = actx.np.linalg.norm(true_local_points - local_points, np.inf)
+            err = flat_norm(true_local_points - local_points, np.inf)
 
             # Can't currently expect exact results due to limitations of
             # interpolation "snapping" in DirectDiscretizationConnection's

--- a/test/test_refinement.py
+++ b/test/test_refinement.py
@@ -31,7 +31,7 @@ from meshmode.array_context import (    # noqa: F401
         pytest_generate_tests_for_pyopencl_array_context
         as pytest_generate_tests)
 
-from meshmode.dof_array import thaw
+from meshmode.dof_array import thaw, flat_norm
 from meshmode.mesh.generation import (  # noqa: F401
         generate_icosahedron, generate_box_mesh, make_curve_mesh, ellipse)
 from meshmode.mesh.refinement.utils import check_nodal_adj_against_geometry
@@ -295,7 +295,7 @@ def test_refinement_connection(
                         ("f_true", f_true),
                         ])
 
-        err = actx.np.linalg.norm(f_interp - f_true, np.inf)
+        err = flat_norm(f_interp - f_true, np.inf)
         eoc_rec.add_data_point(h, err)
 
     order_slack = 0.5


### PR DESCRIPTION
This was previously in #139, but opened a new clean PR without all the unrelated comments.

Current functionality:

* Added a barebones `ArrayContainer` class that just defines a serialization protocol for its components.
* Added a subclass `ArrayContainerWithArithmetic` that should allow to easily add new custom classes. `DOFArray` now steals all its arithmetic from here.
* Implemented a `map_array_container` and `multimap_array_container` that recurses through a tree of containers and applies a function to all their components.
* Implemented a `freeze` and `thaw` based on those that seem to work nicely enough.
* On the `DOFArray` side, added some `map_dof_array_container` and friends that stop recursing when they hit `DOFArrays`.

There's an example in `test_array` that shows how to extend a dataclass and automagically have it do arithmetic through all its fields and stuff like that. (Assuming the fields are `DOFArrays` or something else that knows how to do arithmetic).

Some small things that are left to do
- [x] ~~Remove usage of deprecated `dof_array.thaw` and `dof_array.freeze`~~ (will need to port to `arraycontext` anyway)
- [x] ~~Use `mapped_dof_array_container` instead of `obj_array_vectorize` in connections (elsewhere?) so that they vectorize nicely over array containers.~~ (actually used `multimapped_over_dof_arrays`)
- [x] Use `map_dof_array_container` in connections instead of `multimap_dof_array_container`