### PR TITLE
Track Firedrake changes to FunctionSpace.boundary_nodes

### DIFF
--- a/meshmode/interop/firedrake/connection.py
+++ b/meshmode/interop/firedrake/connection.py
@@ -595,7 +595,7 @@ def _get_cells_to_use(fdrake_mesh, bdy_id):
     cfspace = fdrake_mesh.coordinates.function_space()
     cell_node_list = cfspace.cell_node_list
 
-    boundary_nodes = cfspace.boundary_nodes(bdy_id, "topological")
+    boundary_nodes = cfspace.boundary_nodes(bdy_id)
     # Reduce along each cell: Is a vertex of the cell in boundary nodes?
     cell_is_near_bdy = np.any(np.isin(cell_node_list, boundary_nodes), axis=1)
 


### PR DESCRIPTION
Possible context: https://github.com/firedrakeproject/firedrake/commit/641fdf3d9ce54c26e2b20c1478488d0313b4c351

Hoping to address these failures seen in #181, #175.

```
Traceback (most recent call last):
  File "/__w/meshmode/meshmode/test/test_firedrake_interop.py", line 620, in test_from_fd_idempotency
    restrict_to_boundary="on_boundary")
  File "/home/firedrake/firedrake/lib/python3.6/site-packages/meshmode/interop/firedrake/connection.py", line 725, in build_connection_from_firedrake
    restrict_to_boundary)
  File "/home/firedrake/firedrake/lib/python3.6/site-packages/meshmode/interop/firedrake/connection.py", line 598, in _get_cells_to_use
    boundary_nodes = cfspace.boundary_nodes(bdy_id, "topological")
TypeError: boundary_nodes() takes 2 positional arguments but 3 were given
```

@wence- Is this an appropriate fix?