### PR TITLE
Firedrake CI, fix delay-setting code for oct2py in nodal-dg interop

### DIFF
--- a/.ci/install-for-firedrake.sh
+++ b/.ci/install-for-firedrake.sh
@@ -2,6 +2,9 @@ sudo chown -R $(whoami) /github/home || true
 sudo apt update
 sudo apt upgrade -y
 sudo apt install time
+
+# Otherwise we get missing CL symbols
+export PYOPENCL_CL_PRETEND_VERSION=2.1
 sudo apt install -y pocl-opencl-icd ocl-icd-opencl-dev
 
 . /home/firedrake/firedrake/bin/activate

--- a/.ci/install-for-firedrake.sh
+++ b/.ci/install-for-firedrake.sh
@@ -6,7 +6,6 @@ sudo apt install -y pocl-opencl-icd ocl-icd-opencl-dev
 
 . /home/firedrake/firedrake/bin/activate
 grep -v loopy requirements.txt > /tmp/myreq.txt
-sed -i s/pyopencl.git/pyopencl.git@v2020.2.2/ /tmp/myreq.txt
 
 # no need for these in the Firedrake tests
 sed -i "/boxtree/ d" /tmp/myreq.txt
@@ -23,8 +22,7 @@ pip install dataclasses
 
 pip install pytest
 
-pip install -r /tmp/myreq.txt
-pip install --force-reinstall git+https://github.com/inducer/loopy.git@firedrake-usable_for_potentials
+pip install -r /tmp/myreq.txt 
 
 # Context: https://github.com/OP2/PyOP2/pull/605
 python -m pip install --force-reinstall git+https://github.com/inducer/pytools.git

--- a/meshmode/interop/nodal_dg.py
+++ b/meshmode/interop/nodal_dg.py
@@ -67,7 +67,17 @@ class NodalDGContext:
         # 2s delay still seems to run into
         # "ExceptionPexpect: Could not terminate the child"
         # -AK, 2021-03-28
-        self.octave._engine.repl.delayafterterminate = 15
+
+        delay = 5
+        # make sure we don't set non-existent variables
+        assert self.octave._engine.repl.child.delayafterclose is not None
+        assert self.octave._engine.repl.child.delayafterterminate is not None
+        assert self.octave._engine.repl.child.ptyproc.delayafterclose is not None
+        assert self.octave._engine.repl.child.ptyproc.delayafterterminate is not None
+        self.octave._engine.repl.child.delayafterclose = delay
+        self.octave._engine.repl.child.delayafterterminate = delay
+        self.octave._engine.repl.child.ptyproc.delayafterclose = delay
+        self.octave._engine.repl.child.ptyproc.delayafterterminate = delay
 
         self.octave.exit()
 


### PR DESCRIPTION
This was failing very frequently on gitlab, and I had to go check every time to see if it was an actual failure or just *that again*. It finally annoyed me sufficiently.