### PR TITLE
Port away from meshmode.array_context

### DIFF
--- a/examples/from_firedrake.py
+++ b/examples/from_firedrake.py
@@ -22,6 +22,8 @@ THE SOFTWARE.
 
 import pyopencl as cl
 
+from arraycontext import PyOpenCLArrayContext
+
 
 # This example provides a brief template for bringing information in
 # from firedrake and makes some plots to help you better understand
@@ -50,7 +52,6 @@ def main():
     # Make connections
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
-    from meshmode.array_context import PyOpenCLArrayContext
     actx = PyOpenCLArrayContext(queue)
 
     fd_connection = build_connection_from_firedrake(actx, fd_fspace)

--- a/examples/moving-geometry.py
+++ b/examples/moving-geometry.py
@@ -49,7 +49,7 @@ def plot_solution(actx, vis, filename, discr, t, x):
 def reconstruct_discr_from_nodes(actx, discr, x):
     @memoize_in(actx, (reconstruct_discr_from_nodes, "resample_by_mat_prg"))
     def resample_by_mat_prg():
-        from meshmode.array_context import make_loopy_program
+        from arraycontext import make_loopy_program
         return make_loopy_program(
             """
             {[iel, idof, j]:

--- a/examples/plot-connectivity.py
+++ b/examples/plot-connectivity.py
@@ -1,7 +1,7 @@
 import numpy as np  # noqa
 import pyopencl as cl
-from meshmode.array_context import PyOpenCLArrayContext
-from meshmode.dof_array import thaw
+
+from arraycontext import PyOpenCLArrayContext, thaw
 
 order = 4
 
@@ -29,7 +29,7 @@ def main():
     vis = make_visualizer(actx, discr, order)
 
     vis.write_vtk_file("geometry.vtu", [
-        ("f", thaw(actx, discr.nodes()[0])),
+        ("f", thaw(discr.nodes()[0], actx)),
         ])
 
     from meshmode.discretization.visualization import \

--- a/examples/to_firedrake.py
+++ b/examples/to_firedrake.py
@@ -24,6 +24,8 @@ THE SOFTWARE.
 import numpy as np
 import pyopencl as cl
 
+from arraycontext import PyOpenCLArrayContext, thaw
+
 
 # Nb: Some of the initial setup was adapted from meshmode/examplse/simple-dg.py
 #     written by Andreas Klockner:
@@ -49,7 +51,6 @@ def main():
 
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
-    from meshmode.array_context import PyOpenCLArrayContext
     actx = PyOpenCLArrayContext(queue)
 
     nel_1d = 16
@@ -72,9 +73,8 @@ def main():
     #           = e^x Real(e^{iy})
     #           = e^x cos(y)
     nodes = discr.nodes()
-    from meshmode.dof_array import thaw
     for i in range(len(nodes)):
-        nodes[i] = thaw(actx, nodes[i])
+        nodes[i] = thaw(nodes[i], actx)
     # First index is dimension
     candidate_sol = actx.np.exp(nodes[0]) * actx.np.cos(nodes[1])
 

--- a/meshmode/__init__.py
+++ b/meshmode/__init__.py
@@ -43,7 +43,7 @@ def _acf():
     argument when running them from the command line.
     """
     import pyopencl as cl
-    from meshmode.array_context import PyOpenCLArrayContext
+    from arraycontext import PyOpenCLArrayContext
 
     context = cl._csc()
     queue = cl.CommandQueue(context)

--- a/meshmode/discretization/connection/chained.py
+++ b/meshmode/discretization/connection/chained.py
@@ -276,7 +276,7 @@ def make_full_resample_matrix(actx, connection):
         This method will be very slow, both in terms of speed and memory
         usage, and should only be used for testing or if absolutely necessary.
 
-    :arg actx: a :class:`meshmode.array_context.ArrayContext`.
+    :arg actx: a :class:`arraycontext.ArrayContext`.
     :arg connection: a
         :class:`~meshmode.discretization.connection.DiscretizationConnection`.
     :return: a :class:`pyopencl.array.Array` of shape

--- a/meshmode/discretization/connection/direct.py
+++ b/meshmode/discretization/connection/direct.py
@@ -384,7 +384,7 @@ def make_direct_full_resample_matrix(actx, conn):
         This function assumes a flattened DOF array, as produced by
         :class:`~meshmode.dof_array.flatten`.
 
-    :arg actx: an :class:`~meshmode.array_context.ArrayContext`.
+    :arg actx: an :class:`~arraycontext.ArrayContext`.
     :arg conn: a :class:`DirectDiscretizationConnection`.
     """
 

--- a/meshmode/interop/firedrake/connection.py
+++ b/meshmode/interop/firedrake/connection.py
@@ -436,7 +436,7 @@ class FiredrakeConnection:
                                  " *None* or 'out.array_context'")
         else:
             # If 'out' is not supplied, create it
-            from meshmode.array_context import ArrayContext
+            from arraycontext import ArrayContext
             if not isinstance(actx, ArrayContext):
                 raise TypeError("If 'out' is *None*, 'actx' must be of type "
                                 "ArrayContext, not '%s'." % type(actx))

--- a/meshmode/interop/nodal_dg.py
+++ b/meshmode/interop/nodal_dg.py
@@ -32,10 +32,11 @@ THE SOFTWARE.
 
 
 import numpy as np
+
+import arraycontext
 import meshmode.mesh
 import meshmode.discretization
 import meshmode.dof_array
-import meshmode.array_context
 
 
 class NodalDGContext:
@@ -166,7 +167,7 @@ class NodalDGContext:
         self.octave.push(name, ary.T)
 
     def pull_dof_array(
-            self, actx: meshmode.array_context.ArrayContext, name
+            self, actx: arraycontext.ArrayContext, name
             ) -> meshmode.dof_array.DOFArray:
         ary = self.octave.pull(name).T
 

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -30,6 +30,7 @@ from arraycontext import (  # noqa: F401
         as pytest_generate_tests)
 
 from arraycontext import (
+        thaw,
         dataclass_array_container,
         with_container_arithmetic)
 
@@ -80,9 +81,7 @@ def _get_test_containers(actx, ambient_dim=2):
             b=(+0.5,)*ambient_dim,
             n=(3,)*ambient_dim, order=1)
     discr = Discretization(actx, mesh, PolynomialWarpAndBlendGroupFactory(3))
-
-    from meshmode.array_context import thaw
-    x = thaw(actx, discr.nodes()[0])
+    x = thaw(discr.nodes()[0], actx)
 
     # pylint: disable=unexpected-keyword-arg, no-value-for-parameter
     dataclass_of_dofs = MyContainer(

--- a/test/test_discretization.py
+++ b/test/test_discretization.py
@@ -23,16 +23,16 @@ THE SOFTWARE.
 
 import numpy as np
 # import numpy.linalg as la
+
 import meshmode.mesh.generation as mgen
 from meshmode.discretization import Discretization
-
-from meshmode.array_context import (  # noqa
-        pytest_generate_tests_for_pyopencl_array_context
-        as pytest_generate_tests)
-
 from meshmode.discretization.poly_element import (
         InterpolatoryQuadratureSimplexGroupFactory,
         )
+
+from arraycontext import (          # noqa: F401
+        pytest_generate_tests_for_pyopencl_array_context
+        as pytest_generate_tests)
 
 
 def test_discr_nodes_caching(actx_factory):

--- a/test/test_firedrake_interop.py
+++ b/test/test_firedrake_interop.py
@@ -27,7 +27,7 @@ from pyopencl.tools import (  # noqa
         pytest_generate_tests_for_pyopencl
         as pytest_generate_tests)
 
-from meshmode.array_context import PyOpenCLArrayContext
+from arraycontext import PyOpenCLArrayContext
 
 from meshmode.discretization import Discretization
 from meshmode.discretization.poly_element import (

--- a/test/test_interop.py
+++ b/test/test_interop.py
@@ -24,12 +24,11 @@ THE SOFTWARE.
 import numpy as np
 import pytest
 
-import meshmode         # noqa: F401
-from meshmode.array_context import (  # noqa
+from arraycontext import PyOpenCLArrayContext, thaw, _acf   # noqa: F401
+from arraycontext import (                                  # noqa: F401
         pytest_generate_tests_for_pyopencl_array_context
-        as pytest_generate_tests,
-        PyOpenCLArrayContext)
-from meshmode.dof_array import thaw, flat_norm
+        as pytest_generate_tests)
+from meshmode.dof_array import flat_norm
 
 import logging
 logger = logging.getLogger(__name__)
@@ -60,7 +59,7 @@ def test_nodal_dg_interop(actx_factory, dim):
             err = flat_norm(x_ax-discr.nodes()[ax], np.inf)
             assert err < 1e-15
 
-        n0 = thaw(actx, discr.nodes()[0])
+        n0 = thaw(discr.nodes()[0], actx)
 
         ndgctx.push_dof_array("n0", n0)
         n0_2 = ndgctx.pull_dof_array(actx, "n0")

--- a/test/test_mesh.py
+++ b/test/test_mesh.py
@@ -24,8 +24,9 @@ from functools import partial
 import numpy as np
 import numpy.linalg as la
 import pytest
-import meshmode         # noqa: F401
-from meshmode.array_context import (  # noqa
+
+from arraycontext import _acf       # noqa: F401
+from arraycontext import (          # noqa: F401
         pytest_generate_tests_for_pyopencl_array_context
         as pytest_generate_tests)
 
@@ -35,7 +36,6 @@ from meshmode.discretization.poly_element import (
         LegendreGaussLobattoTensorProductGroupFactory,
         )
 import meshmode.mesh.generation as mgen
-from meshmode import _acf  # noqa: F401
 
 
 import logging

--- a/test/test_modal.py
+++ b/test/test_modal.py
@@ -24,11 +24,12 @@ THE SOFTWARE.
 from functools import partial
 import numpy as np
 
-import meshmode                       # noqa: F401
-from meshmode.array_context import (  # noqa
+from arraycontext import thaw, _acf     # noqa: F401
+from arraycontext import (              # noqa: F401
     pytest_generate_tests_for_pyopencl_array_context
     as pytest_generate_tests
     )
+
 from meshmode.dof_array import DOFArray, flat_norm
 from meshmode.mesh import (
     SimplexElementGroup,
@@ -54,8 +55,6 @@ from meshmode.discretization.connection.modal import (
     NodalToModalDiscretizationConnection,
     ModalToNodalDiscretizationConnection
     )
-
-from meshmode.dof_array import thaw
 
 import meshmode.mesh.generation as mgen
 import pytest
@@ -100,7 +99,7 @@ def test_inverse_modal_connections(actx_factory, nodal_group_factory):
         modal_disc, nodal_disc
     )
 
-    x_nodal = thaw(actx, nodal_disc.nodes()[0])
+    x_nodal = thaw(nodal_disc.nodes()[0], actx)
     nodal_f = f(x_nodal)
 
     # Map nodal coefficients of f to modal coefficients
@@ -142,7 +141,7 @@ def test_modal_coefficients_by_projection(actx_factory, quad_group_factory):
     def f(x):
         return 2*actx.np.sin(5*x)
 
-    x_nodal = thaw(actx, nodal_disc.nodes()[0])
+    x_nodal = thaw(nodal_disc.nodes()[0], actx)
     nodal_f = f(x_nodal)
 
     # Compute modal coefficients we expect to get
@@ -208,7 +207,7 @@ def test_quadrature_based_modal_connection_reverse(actx_factory, quad_group_fact
     def f(x):
         return 1 + 2*x + 3*x**2
 
-    x_nodal = thaw(actx, nodal_disc.nodes()[0])
+    x_nodal = thaw(nodal_disc.nodes()[0], actx)
     nodal_f = f(x_nodal)
 
     # Map nodal coefficients using the quadrature-based projection
@@ -273,7 +272,7 @@ def test_modal_truncation(actx_factory, nodal_group_factory,
             modal_disc, nodal_disc
         )
 
-        x_nodal = thaw(actx, nodal_disc.nodes()[0])
+        x_nodal = thaw(nodal_disc.nodes()[0], actx)
         nodal_f = f(x_nodal)
 
         # Map to modal

--- a/test/test_partition.py
+++ b/test/test_partition.py
@@ -26,9 +26,10 @@ THE SOFTWARE.
 import numpy as np
 import pyopencl as cl
 
-from meshmode.dof_array import thaw, flatten, unflatten, flat_norm
+from meshmode.dof_array import flatten, unflatten, flat_norm
 
-from meshmode.array_context import (  # noqa
+from arraycontext import thaw, _acf         # noqa: F401
+from arraycontext import (                  # noqa: F401
         pytest_generate_tests_for_pyopencl_array_context
         as pytest_generate_tests)
 
@@ -155,7 +156,7 @@ def test_partition_interpolation(actx_factory, dim, mesh_pars,
             check_connection(actx, remote_to_local_conn)
             check_connection(actx, local_to_remote_conn)
 
-            true_local_points = f(thaw(actx, local_bdry.nodes()[0]))
+            true_local_points = f(thaw(local_bdry.nodes()[0], actx))
             remote_points = local_to_remote_conn(true_local_points)
             local_points = remote_to_local_conn(remote_points)
 
@@ -343,7 +344,7 @@ def _test_mpi_boundary_swap(dim, order, num_groups):
 
     group_factory = PolynomialWarpAndBlendGroupFactory(order)
 
-    from meshmode.array_context import PyOpenCLArrayContext
+    from arraycontext import PyOpenCLArrayContext
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(queue)
@@ -436,7 +437,7 @@ def _test_data_transfer(mpi_comm, actx, local_bdry_conns,
     for i_remote_part in connected_parts:
         conn = remote_to_local_bdry_conns[i_remote_part]
         bdry_discr = local_bdry_conns[i_remote_part].to_discr
-        bdry_x = thaw(actx, bdry_discr.nodes()[0])
+        bdry_x = thaw(bdry_discr.nodes()[0], actx)
 
         true_local_f = f(bdry_x)
         remote_f = conn(true_local_f)
@@ -506,7 +507,7 @@ def _test_data_transfer(mpi_comm, actx, local_bdry_conns,
     # 7.
     for i_remote_part in connected_parts:
         bdry_discr = local_bdry_conns[i_remote_part].to_discr
-        bdry_x = thaw(actx, bdry_discr.nodes()[0])
+        bdry_x = thaw(bdry_discr.nodes()[0], actx)
 
         true_local_f = actx.to_numpy(flatten(f(bdry_x)))
         local_f = local_f_data[i_remote_part]

--- a/test/test_refinement.py
+++ b/test/test_refinement.py
@@ -26,14 +26,12 @@ from functools import partial
 import numpy as np
 import pytest
 
-from meshmode import _acf               # noqa: F401
-from meshmode.array_context import (    # noqa: F401
+from arraycontext import thaw, _acf         # noqa: F401
+from arraycontext import (                  # noqa: F401
         pytest_generate_tests_for_pyopencl_array_context
         as pytest_generate_tests)
 
-from meshmode.dof_array import thaw, flat_norm
-from meshmode.mesh.generation import (  # noqa: F401
-        generate_icosahedron, generate_box_mesh, make_curve_mesh, ellipse)
+from meshmode.dof_array import flat_norm
 from meshmode.mesh.refinement.utils import check_nodal_adj_against_geometry
 from meshmode.mesh.refinement import Refiner, RefinerWithoutAdjacency
 import meshmode.mesh.generation as mgen
@@ -101,15 +99,15 @@ def uniform_refine_flags(mesh):
 
     ("3_to_1_ellipse_unif",
         partial(
-            make_curve_mesh,
-            partial(ellipse, 3),
+            mgen.make_curve_mesh,
+            partial(mgen.ellipse, 3),
             np.linspace(0, 1, 21),
             order=1),
         uniform_refine_flags,
         4),
 
     ("rect2d_rand",
-        partial(generate_box_mesh, (
+        partial(mgen.generate_box_mesh, (
             np.linspace(0, 1, 3),
             np.linspace(0, 1, 3),
             ), order=1),
@@ -117,7 +115,7 @@ def uniform_refine_flags(mesh):
         4),
 
     ("rect2d_unif",
-        partial(generate_box_mesh, (
+        partial(mgen.generate_box_mesh, (
             np.linspace(0, 1, 2),
             np.linspace(0, 1, 2),
             ), order=1),
@@ -130,7 +128,7 @@ def uniform_refine_flags(mesh):
         4),
 
     ("rect3d_rand",
-        partial(generate_box_mesh, (
+        partial(mgen.generate_box_mesh, (
             np.linspace(0, 1, 2),
             np.linspace(0, 1, 3),
             np.linspace(0, 1, 2),
@@ -139,7 +137,7 @@ def uniform_refine_flags(mesh):
         3),
 
     ("rect3d_unif",
-        partial(generate_box_mesh, (
+        partial(mgen.generate_box_mesh, (
             np.linspace(0, 1, 2),
             np.linspace(0, 1, 2)), order=1),
         uniform_refine_flags,
@@ -215,8 +213,9 @@ def test_refinement_connection(
         if mesh_name == "circle":
             assert dim == 1
             h = 1 / mesh_par
-            mesh = make_curve_mesh(
-                partial(ellipse, 1), np.linspace(0, 1, mesh_par + 1),
+            mesh = mgen.make_curve_mesh(
+                mgen.circle,
+                np.linspace(0, 1, mesh_par + 1),
                 order=mesh_order)
         elif mesh_name == "blob":
             if mesh_order == 5:
@@ -264,8 +263,8 @@ def test_refinement_connection(
 
         fine_discr = connection.to_discr
 
-        x = thaw(actx, discr.nodes())
-        x_fine = thaw(actx, fine_discr.nodes())
+        x = thaw(discr.nodes(), actx)
+        x_fine = thaw(fine_discr.nodes(), actx)
         f_coarse = f(x)
         f_interp = connection(f_coarse)
         f_true = f(x_fine)
@@ -314,7 +313,7 @@ def test_refinement_connection(
     (TensorProductElementGroup, False)
     ])
 def test_uniform_refinement(group_cls, with_adjacency):
-    make_mesh = partial(generate_box_mesh, (
+    make_mesh = partial(mgen.generate_box_mesh, (
             np.linspace(0.0, 1.0, 2),
             np.linspace(0.0, 1.0, 3),
             np.linspace(0.0, 1.0, 2)),

--- a/test/test_visualization.py
+++ b/test/test_visualization.py
@@ -37,13 +37,12 @@ from meshmode.discretization.poly_element import (
         InterpolatoryQuadratureSimplexGroupFactory,
         LegendreGaussLobattoTensorProductGroupFactory,
         )
-from meshmode.dof_array import thaw
-from meshmode.array_context import (  # noqa
+import meshmode.mesh.generation as mgen
+
+from arraycontext import thaw, _acf         # noqa: F401
+from arraycontext import (                  # noqa: F401
         pytest_generate_tests_for_pyopencl_array_context
         as pytest_generate_tests)
-
-import meshmode.mesh.generation as mgen
-from meshmode import _acf  # noqa: F401
 
 
 # {{{ test visualizer
@@ -159,7 +158,7 @@ def test_visualizers(actx_factory, dim, group_cls):
     from meshmode.discretization import Discretization
     discr = Discretization(actx, mesh, group_factory(target_order))
 
-    nodes = thaw(actx, discr.nodes())
+    nodes = thaw(discr.nodes(), actx)
     f = actx.np.sqrt(sum(nodes**2)) + 1j*nodes[0]
     g = VisualizerData(g=f)
     names_and_fields = [("f", f), ("g", g)]


### PR DESCRIPTION
This should get rid of all the deprecated calls.