### PR TITLE
Revert connection kernels to pre-#192

### DIFF
--- a/meshmode/discretization/connection/direct.py
+++ b/meshmode/discretization/connection/direct.py
@@ -295,24 +295,40 @@ class DirectDiscretizationConnection(DiscretizationConnection):
 
         actx = ary.array_context
 
-        @memoize_in(actx,
-                (DirectDiscretizationConnection, "resample_by_mat_batch_knl"))
-        def batch_mat_knl():
-            return make_loopy_program(
+        @memoize_in(actx, (DirectDiscretizationConnection, "resample_by_mat_knl"))
+        def mat_knl():
+            knl = make_loopy_program(
+                """{[iel, idof, j]:
+                    0<=iel<nelements and
+                    0<=idof<n_to_nodes and
+                    0<=j<n_from_nodes}""",
+                "result[to_element_indices[iel], idof] \
+                    = sum(j, resample_mat[idof, j] \
+                    * ary[from_element_indices[iel], j])",
                 [
-                    "{[iel_init]: 0 <= iel_init < nelements_result}",
-                    "{[idof_init]: 0 <= idof_init < n_to_nodes}",
-                    "{[iel]: 0 <= iel < nelements}",
-                    "{[idof]: 0 <= idof < n_to_nodes}",
-                    "{[jdof]: 0 <= jdof < n_from_nodes}"
-                ],
-                """
-                    result[iel_init, idof_init] = 0 {id=init}
-                    ... gbarrier {id=barrier, dep=init}
-                    result[to_element_indices[iel], idof] =  \
-                        sum(jdof, resample_mat[idof, jdof]   \
-                            * ary[from_element_indices[iel], jdof]) {dep=barrier}
-                """,
+                    lp.GlobalArg("result", None,
+                        shape="nelements_result, n_to_nodes",
+                        offset=lp.auto),
+                    lp.GlobalArg("ary", None,
+                        shape="nelements_vec, n_from_nodes",
+                        offset=lp.auto),
+                    lp.ValueArg("nelements_result", np.int32),
+                    lp.ValueArg("nelements_vec", np.int32),
+                    "...",
+                    ],
+                name="resample_by_mat")
+
+            return knl
+
+        @memoize_in(actx,
+                (DirectDiscretizationConnection, "resample_by_picking_knl"))
+        def pick_knl():
+            knl = make_loopy_program(
+                """{[iel, idof]:
+                    0<=iel<nelements and
+                    0<=idof<n_to_nodes}""",
+                "result[to_element_indices[iel], idof] \
+                    = ary[from_element_indices[iel], pick_list[idof]]",
                 [
                     lp.GlobalArg("result", None,
                         shape="nelements_result, n_to_nodes",
@@ -324,47 +340,17 @@ class DirectDiscretizationConnection(DiscretizationConnection):
                     lp.ValueArg("nelements_vec", np.int32),
                     lp.ValueArg("n_from_nodes", np.int32),
                     "...",
-                ],
-                name="resample_by_mat_batch"
-            )
+                    ],
+                name="resample_by_picking")
 
-        @memoize_in(actx,
-                (DirectDiscretizationConnection, "resample_by_picking_batch_knl"))
-        def batch_pick_knl():
-            return make_loopy_program(
-                [
-                    "{[iel_init]: 0 <= iel_init < nelements_result}",
-                    "{[idof_init]: 0 <= idof_init < n_to_nodes}",
-                    "{[iel]: 0 <= iel < nelements}",
-                    "{[idof]: 0 <= idof < n_to_nodes}"
-                ],
-                """
-                    result[iel_init, idof_init] = 0 {id=init}
-                    ... gbarrier {id=barrier, dep=init}
-                    result[to_element_indices[iel], idof] =              \
-                        ary[from_element_indices[iel], pick_list[idof]]  \
-                            {dep=barrier}
-                """,
-                [
-                    lp.GlobalArg("result", None,
-                        shape="nelements_result, n_to_nodes",
-                        offset=lp.auto),
-                    lp.GlobalArg("ary", None,
-                        shape="nelements_vec, n_from_nodes",
-                        offset=lp.auto),
-                    lp.ValueArg("nelements_result", np.int32),
-                    lp.ValueArg("nelements_vec", np.int32),
-                    lp.ValueArg("n_from_nodes", np.int32),
-                    "...",
-                ],
-                name="resample_by_picking_batch"
-            )
+            return knl
 
-        group_data = []
+        if self.is_surjective:
+            result = self.to_discr.empty(actx, dtype=ary.entry_dtype)
+        else:
+            result = self.to_discr.zeros(actx, dtype=ary.entry_dtype)
+
         for i_tgrp, cgrp in enumerate(self.groups):
-            # Loop over each batch in a group and evaluate the
-            # batch-contribution
-            batched_data = []
             for i_batch, batch in enumerate(cgrp.batches):
                 if not len(batch.from_element_indices):
                     continue
@@ -373,47 +359,23 @@ class DirectDiscretizationConnection(DiscretizationConnection):
                         actx, i_tgrp, i_batch)
 
                 if point_pick_indices is None:
-                    batch_result = actx.call_loopy(
-                        batch_mat_knl(),
-                        resample_mat=self._resample_matrix(
-                            actx, i_tgrp, i_batch
-                        ),
-                        ary=ary[batch.from_group_index],
-                        from_element_indices=batch.from_element_indices,
-                        to_element_indices=batch.to_element_indices,
-                        nelements_result=self.to_discr.groups[i_tgrp].nelements,
-                        n_to_nodes=self.to_discr.groups[i_tgrp].nunit_dofs
-                    )["result"]
+                    actx.call_loopy(mat_knl(),
+                            resample_mat=self._resample_matrix(
+                                actx, i_tgrp, i_batch),
+                            result=result[i_tgrp],
+                            ary=ary[batch.from_group_index],
+                            from_element_indices=batch.from_element_indices,
+                            to_element_indices=batch.to_element_indices)
 
                 else:
-                    batch_result = actx.call_loopy(
-                        batch_pick_knl(),
-                        pick_list=point_pick_indices,
-                        ary=ary[batch.from_group_index],
-                        from_element_indices=batch.from_element_indices,
-                        to_element_indices=batch.to_element_indices,
-                        nelements_result=self.to_discr.groups[i_tgrp].nelements,
-                        n_to_nodes=self.to_discr.groups[i_tgrp].nunit_dofs
-                    )["result"]
+                    actx.call_loopy(pick_knl(),
+                            pick_list=point_pick_indices,
+                            result=result[i_tgrp],
+                            ary=ary[batch.from_group_index],
+                            from_element_indices=batch.from_element_indices,
+                            to_element_indices=batch.to_element_indices)
 
-                batched_data.append(batch_result)
-
-            # After computing each batched result, take the sum
-            # to get the entire contribution over the group
-            if batched_data:
-                group_data.append(sum(batched_data))
-            else:
-                # If no batched data at all, return zeros for this
-                # particular group array
-                group_data.append(
-                    actx.zeros(
-                        shape=(self.to_discr.groups[i_tgrp].nelements,
-                               self.to_discr.groups[i_tgrp].nunit_dofs),
-                        dtype=ary.entry_dtype
-                    )
-                )
-
-        return DOFArray(actx, data=tuple(group_data))
+        return result
 
 # }}}
 

--- a/meshmode/discretization/connection/projection.py
+++ b/meshmode/discretization/connection/projection.py
@@ -134,76 +134,81 @@ class L2ProjectionInverseDiscretizationConnection(DiscretizationConnection):
         @memoize_in(actx, (L2ProjectionInverseDiscretizationConnection,
             "conn_projection_knl"))
         def kproj():
-            return make_loopy_program(
-                [
-                    "{[iel_init]: 0 <= iel_init < n_to_elements}",
-                    "{[idof_init]: 0 <= idof_init < n_to_nodes}",
-                    "{[iel]: 0 <= iel < nelements}",
-                    "{[i_quad]: 0 <= i_quad < n_to_nodes}",
-                    "{[ibasis]: 0 <= ibasis < n_to_nodes}"
+            return make_loopy_program([
+                "{[iel]: 0 <= iel < nelements}",
+                "{[idof_quad]: 0 <= idof_quad < n_from_nodes}"
                 ],
                 """
-                    result[iel_init, idof_init] = 0 {id=init}
-                    ... gbarrier {id=barrier, dep=init}
-                    result[to_element_indices[iel], ibasis] =               \
-                        result[to_element_indices[iel], ibasis] +           \
-                        sum(i_quad, ary[from_element_indices[iel], i_quad]  \
-                                    * basis_tabulation[ibasis, i_quad]      \
-                                    * weights[i_quad]) {dep=barrier}
+                for iel
+                    <> element_dot = sum(idof_quad,
+                                ary[from_element_indices[iel], idof_quad]
+                                * basis[idof_quad] * weights[idof_quad])
+                    result[to_element_indices[iel], ibasis] = \
+                            result[to_element_indices[iel], ibasis] + element_dot
+                end
                 """,
                 [
                     lp.GlobalArg("ary", None,
-                                 shape=("n_from_elements", "n_from_nodes")),
+                        shape=("n_from_elements", "n_from_nodes")),
                     lp.GlobalArg("result", None,
-                                 shape=("n_to_elements", "n_to_nodes")),
-                    lp.GlobalArg("basis_tabulation", None,
-                                 shape=("n_to_nodes", "n_to_nodes")),
+                        shape=("n_to_elements", "n_to_nodes")),
+                    lp.GlobalArg("basis", None,
+                        shape="n_from_nodes"),
                     lp.GlobalArg("weights", None,
-                                 shape="n_from_nodes"),
+                        shape="n_from_nodes"),
                     lp.ValueArg("n_from_elements", np.int32),
-                    lp.ValueArg("n_from_nodes", np.int32),
                     lp.ValueArg("n_to_elements", np.int32),
                     lp.ValueArg("n_to_nodes", np.int32),
+                    lp.ValueArg("ibasis", np.int32),
                     "..."
+                    ],
+                name="conn_projection_knl")
+
+        @memoize_in(actx, (L2ProjectionInverseDiscretizationConnection,
+            "conn_evaluation_knl"))
+        def keval():
+            return make_loopy_program([
+                "{[iel]: 0 <= iel < nelements}",
+                "{[idof]: 0 <= idof < n_to_nodes}",
+                "{[ibasis]: 0 <= ibasis < n_to_nodes}"
                 ],
-                name="conn_projection_knl"
-            )
+                """
+                    result[iel, idof] = result[iel, idof] + \
+                        sum(ibasis, vdm[idof, ibasis] * coefficients[iel, ibasis])
+                """,
+                [
+                    lp.GlobalArg("coefficients", None,
+                        shape=("nelements", "n_to_nodes")),
+                    "..."
+                    ],
+                name="conn_evaluate_knl")
 
         # compute weights on each refinement of the reference element
         weights = self._batch_weights(actx)
 
         # perform dot product (on reference element) to get basis coefficients
-        c_group_data = []
+        coefficients = self.to_discr.zeros(actx, dtype=ary.entry_dtype)
+
         for igrp, cgrp in enumerate(self.conn.groups):
-            c_batch_data = []
             for ibatch, batch in enumerate(cgrp.batches):
                 sgrp = self.from_discr.groups[batch.from_group_index]
 
-                # Generate the basis tabulation matrix
-                tabulations = []
-                for basis_fn in sgrp.basis_obj().functions:
-                    tabulations.append(basis_fn(batch.result_unit_nodes).flatten())
-                tabulations = actx.from_numpy(np.asarray(tabulations))
+                for ibasis, basis_fn in enumerate(sgrp.basis_obj().functions):
+                    basis = actx.from_numpy(
+                            basis_fn(batch.result_unit_nodes).flatten())
 
-                # NOTE: batch.*_element_indices are reversed here because
-                # they are from the original forward connection, but
-                # we are going in reverse here. a bit confusing, but
-                # saves on recreating the connection groups and batches.
-                c_batch_data.append(
-                    actx.call_loopy(
-                        kproj(),
-                        ary=ary[sgrp.index],
-                        basis_tabulation=tabulations,
-                        weights=weights[igrp, ibatch],
-                        from_element_indices=batch.to_element_indices,
-                        to_element_indices=batch.from_element_indices,
-                        n_to_elements=self.to_discr.groups[igrp].nelements,
-                        n_to_nodes=self.to_discr.groups[igrp].nunit_dofs,
-                    )["result"]
-                )
-
-            c_group_data.append(sum(c_batch_data))
-        coefficients = DOFArray(actx, data=tuple(c_group_data))
+                    # NOTE: batch.*_element_indices are reversed here because
+                    # they are from the original forward connection, but
+                    # we are going in reverse here. a bit confusing, but
+                    # saves on recreating the connection groups and batches.
+                    actx.call_loopy(kproj(),
+                            ibasis=ibasis,
+                            ary=ary[sgrp.index],
+                            basis=basis,
+                            weights=weights[igrp, ibatch],
+                            result=coefficients[igrp],
+                            from_element_indices=batch.to_element_indices,
+                            to_element_indices=batch.from_element_indices)
 
         @keyed_memoize_in(
             actx, (L2ProjectionInverseDiscretizationConnection,


### PR DESCRIPTION
So the source of the slow-down @MTCam and @anderson2981 observed can basically be traced back to the connections. Reverting the changes applied by #192 in the connection kernels (didn't revert everything) appears to eliminate the large drop in speed.

I know these aren't "lazy compatible" but I think time should be spent figuring out a robust way to do these connections, that doesn't have really bad performance penalties.