### PR TITLE
Undo revert of connection kernels to pre-#192

### DIFF
--- a/.ci/install-for-firedrake.sh
+++ b/.ci/install-for-firedrake.sh
@@ -25,9 +25,9 @@ pip install dataclasses
 
 pip install pytest
 
-pip install -r /tmp/myreq.txt
+pip install -r /tmp/myreq.txt 
 
-# Use updated loopy for test
-python -m pip install --force-reinstall git+https://github.com/inducer/loopy.git
+# Context: https://github.com/OP2/PyOP2/pull/605
+python -m pip install --force-reinstall git+https://github.com/inducer/pytools.git
 
 pip install .

--- a/.ci/install-for-firedrake.sh
+++ b/.ci/install-for-firedrake.sh
@@ -25,9 +25,9 @@ pip install dataclasses
 
 pip install pytest
 
-pip install -r /tmp/myreq.txt 
+pip install -r /tmp/myreq.txt
 
-# Context: https://github.com/OP2/PyOP2/pull/605
-python -m pip install --force-reinstall git+https://github.com/inducer/pytools.git
+# Use updated loopy for test
+python -m pip install --force-reinstall git+https://github.com/inducer/loopy.git
 
 pip install .

--- a/meshmode/discretization/connection/direct.py
+++ b/meshmode/discretization/connection/direct.py
@@ -370,7 +370,7 @@ class DirectDiscretizationConnection(DiscretizationConnection):
         actx = ary.array_context
 
         @memoize_in(actx,
-                (DirectDiscretizationConnection, "resample_by_mat_batch_knl"))
+                (DirectDiscretizationConnection, "resample_by_mat_knl"))
         def batch_mat_knl():
             return make_loopy_program(
                 [
@@ -391,11 +391,11 @@ class DirectDiscretizationConnection(DiscretizationConnection):
                     lp.ValueArg("nelements_vec", np.int32),
                     "...",
                 ],
-                name="resample_by_mat_batch",
+                name="resample_by_mat",
             )
 
         @memoize_in(actx,
-                (DirectDiscretizationConnection, "resample_by_picking_batch_knl"))
+                (DirectDiscretizationConnection, "resample_by_picking_knl"))
         def batch_pick_knl():
             return make_loopy_program(
                 [
@@ -415,7 +415,7 @@ class DirectDiscretizationConnection(DiscretizationConnection):
                     lp.ValueArg("n_from_nodes", np.int32),
                     "...",
                 ],
-                name="resample_by_picking_batch",
+                name="resample_by_picking",
             )
 
         group_data = []
@@ -478,7 +478,8 @@ class DirectDiscretizationConnection(DiscretizationConnection):
     def _apply_with_inplace_updates(self, ary):
         actx = ary.array_context
 
-        @memoize_in(actx, (DirectDiscretizationConnection, "resample_by_mat_knl"))
+        @memoize_in(actx, (DirectDiscretizationConnection,
+            "resample_by_mat_knl_inplace"))
         def mat_knl():
             knl = make_loopy_program(
                 """{[iel, idof, j]:
@@ -499,12 +500,12 @@ class DirectDiscretizationConnection(DiscretizationConnection):
                     lp.ValueArg("nelements_vec", np.int32),
                     "...",
                     ],
-                name="resample_by_mat")
+                name="resample_by_mat_inplace")
 
             return knl
 
         @memoize_in(actx,
-                (DirectDiscretizationConnection, "resample_by_picking_knl"))
+                (DirectDiscretizationConnection, "resample_by_picking_knl_inplace"))
         def pick_knl():
             knl = make_loopy_program(
                 """{[iel, idof]:
@@ -524,7 +525,7 @@ class DirectDiscretizationConnection(DiscretizationConnection):
                     lp.ValueArg("n_from_nodes", np.int32),
                     "...",
                     ],
-                name="resample_by_picking")
+                name="resample_by_picking_inplace")
 
             return knl
 

--- a/meshmode/discretization/connection/direct.py
+++ b/meshmode/discretization/connection/direct.py
@@ -295,40 +295,24 @@ class DirectDiscretizationConnection(DiscretizationConnection):
 
         actx = ary.array_context
 
-        @memoize_in(actx, (DirectDiscretizationConnection, "resample_by_mat_knl"))
-        def mat_knl():
-            knl = make_loopy_program(
-                """{[iel, idof, j]:
-                    0<=iel<nelements and
-                    0<=idof<n_to_nodes and
-                    0<=j<n_from_nodes}""",
-                "result[to_element_indices[iel], idof] \
-                    = sum(j, resample_mat[idof, j] \
-                    * ary[from_element_indices[iel], j])",
-                [
-                    lp.GlobalArg("result", None,
-                        shape="nelements_result, n_to_nodes",
-                        offset=lp.auto),
-                    lp.GlobalArg("ary", None,
-                        shape="nelements_vec, n_from_nodes",
-                        offset=lp.auto),
-                    lp.ValueArg("nelements_result", np.int32),
-                    lp.ValueArg("nelements_vec", np.int32),
-                    "...",
-                    ],
-                name="resample_by_mat")
-
-            return knl
-
         @memoize_in(actx,
-                (DirectDiscretizationConnection, "resample_by_picking_knl"))
-        def pick_knl():
-            knl = make_loopy_program(
-                """{[iel, idof]:
-                    0<=iel<nelements and
-                    0<=idof<n_to_nodes}""",
-                "result[to_element_indices[iel], idof] \
-                    = ary[from_element_indices[iel], pick_list[idof]]",
+                (DirectDiscretizationConnection, "resample_by_mat_batch_knl"))
+        def batch_mat_knl():
+            return make_loopy_program(
+                [
+                    "{[iel_init]: 0 <= iel_init < nelements_result}",
+                    "{[idof_init]: 0 <= idof_init < n_to_nodes}",
+                    "{[iel]: 0 <= iel < nelements}",
+                    "{[idof]: 0 <= idof < n_to_nodes}",
+                    "{[jdof]: 0 <= jdof < n_from_nodes}"
+                ],
+                """
+                    result[iel_init, idof_init] = 0 {id=init}
+                    ... gbarrier {id=barrier, dep=init}
+                    result[to_element_indices[iel], idof] =  \
+                        sum(jdof, resample_mat[idof, jdof]   \
+                            * ary[from_element_indices[iel], jdof]) {dep=barrier}
+                """,
                 [
                     lp.GlobalArg("result", None,
                         shape="nelements_result, n_to_nodes",
@@ -340,17 +324,47 @@ class DirectDiscretizationConnection(DiscretizationConnection):
                     lp.ValueArg("nelements_vec", np.int32),
                     lp.ValueArg("n_from_nodes", np.int32),
                     "...",
-                    ],
-                name="resample_by_picking")
+                ],
+                name="resample_by_mat_batch"
+            )
 
-            return knl
+        @memoize_in(actx,
+                (DirectDiscretizationConnection, "resample_by_picking_batch_knl"))
+        def batch_pick_knl():
+            return make_loopy_program(
+                [
+                    "{[iel_init]: 0 <= iel_init < nelements_result}",
+                    "{[idof_init]: 0 <= idof_init < n_to_nodes}",
+                    "{[iel]: 0 <= iel < nelements}",
+                    "{[idof]: 0 <= idof < n_to_nodes}"
+                ],
+                """
+                    result[iel_init, idof_init] = 0 {id=init}
+                    ... gbarrier {id=barrier, dep=init}
+                    result[to_element_indices[iel], idof] =              \
+                        ary[from_element_indices[iel], pick_list[idof]]  \
+                            {dep=barrier}
+                """,
+                [
+                    lp.GlobalArg("result", None,
+                        shape="nelements_result, n_to_nodes",
+                        offset=lp.auto),
+                    lp.GlobalArg("ary", None,
+                        shape="nelements_vec, n_from_nodes",
+                        offset=lp.auto),
+                    lp.ValueArg("nelements_result", np.int32),
+                    lp.ValueArg("nelements_vec", np.int32),
+                    lp.ValueArg("n_from_nodes", np.int32),
+                    "...",
+                ],
+                name="resample_by_picking_batch"
+            )
 
-        if self.is_surjective:
-            result = self.to_discr.empty(actx, dtype=ary.entry_dtype)
-        else:
-            result = self.to_discr.zeros(actx, dtype=ary.entry_dtype)
-
+        group_data = []
         for i_tgrp, cgrp in enumerate(self.groups):
+            # Loop over each batch in a group and evaluate the
+            # batch-contribution
+            batched_data = []
             for i_batch, batch in enumerate(cgrp.batches):
                 if not len(batch.from_element_indices):
                     continue
@@ -359,23 +373,47 @@ class DirectDiscretizationConnection(DiscretizationConnection):
                         actx, i_tgrp, i_batch)
 
                 if point_pick_indices is None:
-                    actx.call_loopy(mat_knl(),
-                            resample_mat=self._resample_matrix(
-                                actx, i_tgrp, i_batch),
-                            result=result[i_tgrp],
-                            ary=ary[batch.from_group_index],
-                            from_element_indices=batch.from_element_indices,
-                            to_element_indices=batch.to_element_indices)
+                    batch_result = actx.call_loopy(
+                        batch_mat_knl(),
+                        resample_mat=self._resample_matrix(
+                            actx, i_tgrp, i_batch
+                        ),
+                        ary=ary[batch.from_group_index],
+                        from_element_indices=batch.from_element_indices,
+                        to_element_indices=batch.to_element_indices,
+                        nelements_result=self.to_discr.groups[i_tgrp].nelements,
+                        n_to_nodes=self.to_discr.groups[i_tgrp].nunit_dofs
+                    )["result"]
 
                 else:
-                    actx.call_loopy(pick_knl(),
-                            pick_list=point_pick_indices,
-                            result=result[i_tgrp],
-                            ary=ary[batch.from_group_index],
-                            from_element_indices=batch.from_element_indices,
-                            to_element_indices=batch.to_element_indices)
+                    batch_result = actx.call_loopy(
+                        batch_pick_knl(),
+                        pick_list=point_pick_indices,
+                        ary=ary[batch.from_group_index],
+                        from_element_indices=batch.from_element_indices,
+                        to_element_indices=batch.to_element_indices,
+                        nelements_result=self.to_discr.groups[i_tgrp].nelements,
+                        n_to_nodes=self.to_discr.groups[i_tgrp].nunit_dofs
+                    )["result"]
 
-        return result
+                batched_data.append(batch_result)
+
+            # After computing each batched result, take the sum
+            # to get the entire contribution over the group
+            if batched_data:
+                group_data.append(sum(batched_data))
+            else:
+                # If no batched data at all, return zeros for this
+                # particular group array
+                group_data.append(
+                    actx.zeros(
+                        shape=(self.to_discr.groups[i_tgrp].nelements,
+                               self.to_discr.groups[i_tgrp].nunit_dofs),
+                        dtype=ary.entry_dtype
+                    )
+                )
+
+        return DOFArray(actx, data=tuple(group_data))
 
 # }}}
 

--- a/meshmode/discretization/connection/direct.py
+++ b/meshmode/discretization/connection/direct.py
@@ -295,10 +295,12 @@ class DirectDiscretizationConnection(DiscretizationConnection):
 
         actx = ary.array_context
 
+        from arraycontext.metadata import ElementInameTag, DOFInameTag
+
         @memoize_in(actx,
                 (DirectDiscretizationConnection, "resample_by_mat_batch_knl"))
         def batch_mat_knl():
-            return make_loopy_program(
+            t_unit = make_loopy_program(
                 [
                     "{[iel_init]: 0 <= iel_init < nelements_result}",
                     "{[idof_init]: 0 <= idof_init < n_to_nodes}",
@@ -325,13 +327,20 @@ class DirectDiscretizationConnection(DiscretizationConnection):
                     lp.ValueArg("n_from_nodes", np.int32),
                     "...",
                 ],
-                name="resample_by_mat_batch"
+                name="resample_by_mat_batch",
             )
+            t_unit = lp.tag_inames(t_unit, {
+                "iel_init": ElementInameTag(),
+                "iel": ElementInameTag(),
+                "idof_init": DOFInameTag(),
+                "idof": DOFInameTag(),
+                })
+            return t_unit
 
         @memoize_in(actx,
                 (DirectDiscretizationConnection, "resample_by_picking_batch_knl"))
         def batch_pick_knl():
-            return make_loopy_program(
+            t_unit = make_loopy_program(
                 [
                     "{[iel_init]: 0 <= iel_init < nelements_result}",
                     "{[idof_init]: 0 <= idof_init < n_to_nodes}",
@@ -357,8 +366,15 @@ class DirectDiscretizationConnection(DiscretizationConnection):
                     lp.ValueArg("n_from_nodes", np.int32),
                     "...",
                 ],
-                name="resample_by_picking_batch"
+                name="resample_by_picking_batch",
             )
+            t_unit = lp.tag_inames(t_unit, {
+                "iel_init": ElementInameTag(),
+                "iel": ElementInameTag(),
+                "idof_init": DOFInameTag(),
+                "idof": DOFInameTag(),
+                })
+            return t_unit
 
         group_data = []
         for i_tgrp, cgrp in enumerate(self.groups):

--- a/meshmode/discretization/connection/direct.py
+++ b/meshmode/discretization/connection/direct.py
@@ -342,7 +342,10 @@ class DirectDiscretizationConnection(DiscretizationConnection):
 
         return make_direct_full_resample_matrix(actx, self)
 
-    def __call__(self, ary):
+    def __call__(self, ary, _force_no_inplace_updates=False):
+        # _force_no_inplace_updates: Only used to ensure test coverage
+        # of both code paths.
+
         from meshmode.dof_array import DOFArray
         if is_array_container(ary) and not isinstance(ary, DOFArray):
             return map_array_container(self, ary)
@@ -353,6 +356,16 @@ class DirectDiscretizationConnection(DiscretizationConnection):
         if ary.shape != (len(self.from_discr.groups),):
             raise ValueError("invalid shape of incoming resampling data")
 
+        if (ary.array_context.permits_inplace_modification
+                and not _force_no_inplace_updates):
+            return self._apply_with_inplace_updates(ary)
+        else:
+            return self._apply_without_inplace_updates(ary)
+
+    # {{{ _apply_without_inplace_updates
+
+    def _apply_without_inplace_updates(self, ary):
+        from meshmode.dof_array import DOFArray
         actx = ary.array_context
 
         @memoize_in(actx,
@@ -466,6 +479,97 @@ class DirectDiscretizationConnection(DiscretizationConnection):
                 )
 
         return DOFArray(actx, data=tuple(group_data))
+
+    # }}}
+
+    # {{{ _apply_with_inplace_updates
+
+    def _apply_with_inplace_updates(self, ary):
+        actx = ary.array_context
+
+        @memoize_in(actx, (DirectDiscretizationConnection, "resample_by_mat_knl"))
+        def mat_knl():
+            knl = make_loopy_program(
+                """{[iel, idof, j]:
+                    0<=iel<nelements and
+                    0<=idof<n_to_nodes and
+                    0<=j<n_from_nodes}""",
+                "result[to_element_indices[iel], idof] \
+                    = sum(j, resample_mat[idof, j] \
+                    * ary[from_element_indices[iel], j])",
+                [
+                    lp.GlobalArg("result", None,
+                        shape="nelements_result, n_to_nodes",
+                        offset=lp.auto),
+                    lp.GlobalArg("ary", None,
+                        shape="nelements_vec, n_from_nodes",
+                        offset=lp.auto),
+                    lp.ValueArg("nelements_result", np.int32),
+                    lp.ValueArg("nelements_vec", np.int32),
+                    "...",
+                    ],
+                name="resample_by_mat")
+
+            return knl
+
+        @memoize_in(actx,
+                (DirectDiscretizationConnection, "resample_by_picking_knl"))
+        def pick_knl():
+            knl = make_loopy_program(
+                """{[iel, idof]:
+                    0<=iel<nelements and
+                    0<=idof<n_to_nodes}""",
+                "result[to_element_indices[iel], idof] \
+                    = ary[from_element_indices[iel], pick_list[idof]]",
+                [
+                    lp.GlobalArg("result", None,
+                        shape="nelements_result, n_to_nodes",
+                        offset=lp.auto),
+                    lp.GlobalArg("ary", None,
+                        shape="nelements_vec, n_from_nodes",
+                        offset=lp.auto),
+                    lp.ValueArg("nelements_result", np.int32),
+                    lp.ValueArg("nelements_vec", np.int32),
+                    lp.ValueArg("n_from_nodes", np.int32),
+                    "...",
+                    ],
+                name="resample_by_picking")
+
+            return knl
+
+        if self.is_surjective:
+            result = self.to_discr.empty(actx, dtype=ary.entry_dtype)
+        else:
+            result = self.to_discr.zeros(actx, dtype=ary.entry_dtype)
+
+        for i_tgrp, cgrp in enumerate(self.groups):
+            for i_batch, batch in enumerate(cgrp.batches):
+                if not len(batch.from_element_indices):
+                    continue
+
+                point_pick_indices = self._resample_point_pick_indices(
+                        actx, i_tgrp, i_batch)
+
+                if point_pick_indices is None:
+                    actx.call_loopy(mat_knl(),
+                            resample_mat=self._resample_matrix(
+                                actx, i_tgrp, i_batch),
+                            result=result[i_tgrp],
+                            ary=ary[batch.from_group_index],
+                            from_element_indices=batch.from_element_indices,
+                            to_element_indices=batch.to_element_indices)
+
+                else:
+                    actx.call_loopy(pick_knl(),
+                            pick_list=point_pick_indices,
+                            result=result[i_tgrp],
+                            ary=ary[batch.from_group_index],
+                            from_element_indices=batch.from_element_indices,
+                            to_element_indices=batch.to_element_indices)
+
+        return result
+
+    # }}}
 
 # }}}
 

--- a/meshmode/discretization/connection/direct.py
+++ b/meshmode/discretization/connection/direct.py
@@ -371,7 +371,7 @@ class DirectDiscretizationConnection(DiscretizationConnection):
         @memoize_in(actx,
                 (DirectDiscretizationConnection, "resample_by_mat_batch_knl"))
         def batch_mat_knl():
-            t_unit = make_loopy_program(
+            return make_loopy_program(
                 [
                     "{[iel]: 0 <= iel < nelements}",
                     "{[idof]: 0 <= idof < n_to_nodes}",
@@ -392,16 +392,11 @@ class DirectDiscretizationConnection(DiscretizationConnection):
                 ],
                 name="resample_by_mat_batch",
             )
-            t_unit = lp.tag_inames(t_unit, {
-                "iel": ElementInameTag(),
-                "idof": DOFInameTag(),
-                })
-            return t_unit
 
         @memoize_in(actx,
                 (DirectDiscretizationConnection, "resample_by_picking_batch_knl"))
         def batch_pick_knl():
-            t_unit = make_loopy_program(
+            return make_loopy_program(
                 [
                     "{[iel]: 0 <= iel < nelements}",
                     "{[idof]: 0 <= idof < n_to_nodes}"
@@ -421,11 +416,6 @@ class DirectDiscretizationConnection(DiscretizationConnection):
                 ],
                 name="resample_by_picking_batch",
             )
-            t_unit = lp.tag_inames(t_unit, {
-                "iel": ElementInameTag(),
-                "idof": DOFInameTag(),
-                })
-            return t_unit
 
         group_data = []
         for i_tgrp, cgrp in enumerate(self.groups):

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ git+https://github.com/inducer/pymbolic.git#egg=pymbolic
 git+https://github.com/inducer/loopy.git#egg=loopy
 
 # depends on loopy, so should come after it.
-git+https://github.com/inducer/arraycontext.git@iname-tag-transform#egg=arraycontext
+git+https://github.com/inducer/arraycontext.git#egg=arraycontext
 
 # more pytential dependencies
 git+https://github.com/inducer/boxtree.git#egg=boxtree

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,13 +7,14 @@ git+https://github.com/inducer/modepy.git#egg=modepy
 git+https://github.com/inducer/pyopencl.git#egg=pyopencl
 git+https://github.com/inducer/islpy.git#egg=islpy
 
-git+https://github.com/inducer/arraycontext.git#egg=arraycontext
-
 # required by pytential, which is in turn needed for some tests
 git+https://github.com/inducer/pymbolic.git#egg=pymbolic
 
 # also depends on pymbolic, so should come after it
-git+https://github.com/inducer/loopy.git#egg=loopy
+git+https://github.com/inducer/loopy.git@iname-tags#egg=loopy
+
+# depends on loopy, so should come after it.
+git+https://github.com/inducer/arraycontext.git@iname-tag-transform#egg=arraycontext
 
 # more pytential dependencies
 git+https://github.com/inducer/boxtree.git#egg=boxtree

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ git+https://github.com/inducer/islpy.git#egg=islpy
 git+https://github.com/inducer/pymbolic.git#egg=pymbolic
 
 # also depends on pymbolic, so should come after it
-git+https://github.com/inducer/loopy.git@iname-tags#egg=loopy
+git+https://github.com/inducer/loopy.git#egg=loopy
 
 # depends on loopy, so should come after it.
 git+https://github.com/inducer/arraycontext.git@iname-tag-transform#egg=arraycontext

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -31,6 +31,8 @@ from arraycontext import (  # noqa
         as pytest_generate_tests,
         thaw)
 
+from arraycontext import _acf  # noqa: F401
+
 from meshmode.mesh import SimplexElementGroup, TensorProductElementGroup
 from meshmode.discretization.poly_element import (
         InterpolatoryQuadratureSimplexGroupFactory,

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -417,6 +417,10 @@ def test_opposite_face_interpolation(actx_factory, group_factory,
         bdry_f = f(bdry_x)
         bdry_f_2 = opp_face(bdry_f)
 
+        # Ensure test coverage for non-in-place kernels in DirectConnection
+        bdry_f_2_no_inp = opp_face(bdry_f, _force_no_inplace_updates=True)
+        assert flat_norm(bdry_f_2-bdry_f_2_no_inp, np.inf) < 1e-14
+
         err = flat_norm(bdry_f-bdry_f_2, np.inf)
         eoc_rec.add_data_point(h, err)
 
@@ -849,6 +853,11 @@ def test_mesh_multiple_groups(actx_factory, ambient_dim, visualize=False):
             check_connection(actx, opposite)
 
             op_bdry_f = opposite(bdry_f)
+
+            # Ensure test coverage for non-in-place kernels in DirectConnection
+            op_bdry_f_no_inplace = opposite(bdry_f, _force_no_inplace_updates=True)
+            assert flat_norm(op_bdry_f - op_bdry_f_no_inplace, np.inf) < 1e-15
+
             error = flat_norm(bdry_f - op_bdry_f, np.inf)
             assert error < 1.0e-11, error
 


### PR DESCRIPTION
This reverts #217 and thereby makes meshmode lazy-compatible again. 

In an earlier version of this, I said:

> There should not be a performance hit this time.

Turns out that that statement was a bit optimistic. See below.

- [x] Needs https://github.com/inducer/loopy/pull/410
- [x] ~~Needs https://github.com/inducer/arraycontext/pull/29 (for now, until meshmode gets its own `PyOpenCLArrayContext`)~~
- [x] `requirements.txt` should be pointed back to main

cc @thomasgibson @matthiasdiener 