### PR TITLE
Add relative path support for visualization file names.

### DIFF
--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -641,8 +641,9 @@ class Visualizer:
                 par_manifest_filename=par_manifest_filename,
                 par_file_names=[
                     file_name_pattern.format(rank=rank)
-                    for rank in range(nranks)]
-        )
+                    for rank in range(nranks)
+                    ]
+                )
 
     def write_vtk_file(self, file_name, names_and_fields,
             compressor=None, real_only=False, overwrite=False,

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -807,7 +807,7 @@ class Visualizer:
 
             if responsible_for_writing_par_manifest:
                 parfile_relnames = [
-                    os.path.relpath(pn, start=os.dirname(par_manifest_filename))
+                    os.path.relpath(pn, start=os.path.dirname(par_manifest_filename))
                     for pn in par_file_names]
                 with open(par_manifest_filename, "w") as outf:
                     generator = ParallelXMLGenerator(parfile_relnames)

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -604,7 +604,8 @@ class Visualizer:
             is assumed.
         :arg file_name_pattern: A file name pattern (required to end in ``.vtu``)
             that will be used with :meth:`str.format` with an (integer)
-            argument of ``rank`` to obtain the per-rank file name.
+            argument of ``rank`` to obtain the per-rank file name. Relative
+            path names are also supported.
         :arg par_manifest_filename: as in :meth:`write_vtk_file`.
             If not given, *par_manifest_filename* is synthesized by
             substituting rank 0 into *file_name_pattern* and replacing the file
@@ -629,7 +630,8 @@ class Visualizer:
                         "ending in '.vtu'")
 
             par_manifest_filename = par_manifest_filename[:-4] + ".pvtu"
-
+    
+        import os
         self.write_vtk_file(
                 file_name=file_name_pattern.format(rank=rank),
                 names_and_fields=names_and_fields,
@@ -639,7 +641,7 @@ class Visualizer:
                 use_high_order=use_high_order,
                 par_manifest_filename=par_manifest_filename,
                 par_file_names=[
-                    file_name_pattern.format(rank=rank)
+                    os.path.basename(file_name_pattern.format(rank=rank))
                     for rank in range(nranks)
                     ]
                 )

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -631,7 +631,6 @@ class Visualizer:
 
             par_manifest_filename = par_manifest_filename[:-4] + ".pvtu"
 
-        import os
         self.write_vtk_file(
                 file_name=file_name_pattern.format(rank=rank),
                 names_and_fields=names_and_fields,
@@ -641,10 +640,9 @@ class Visualizer:
                 use_high_order=use_high_order,
                 par_manifest_filename=par_manifest_filename,
                 par_file_names=[
-                    os.path.basename(file_name_pattern.format(rank=rank))
-                    for rank in range(nranks)
-                    ]
-                )
+                    file_name_pattern.format(rank=rank)
+                    for rank in range(nranks)]
+        )
 
     def write_vtk_file(self, file_name, names_and_fields,
             compressor=None, real_only=False, overwrite=False,
@@ -807,8 +805,11 @@ class Visualizer:
                         "par_file_names are given")
 
             if responsible_for_writing_par_manifest:
+                parfile_relnames = [
+                    os.path.relpath(pn, start=os.dirname(par_manifest_filename))
+                    for pn in par_file_names]
                 with open(par_manifest_filename, "w") as outf:
-                    generator = ParallelXMLGenerator(par_file_names)
+                    generator = ParallelXMLGenerator(parfile_relnames)
                     generator(grid).write(outf)
 
         # }}}

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -630,7 +630,7 @@ class Visualizer:
                         "ending in '.vtu'")
 
             par_manifest_filename = par_manifest_filename[:-4] + ".pvtu"
-    
+
         import os
         self.write_vtk_file(
                 file_name=file_name_pattern.format(rank=rank),


### PR DESCRIPTION
This adds relative file path support for visualization file names.

Without this change, specifying relative filenames for the visualization file works OK, except for the filenames listed in the parallel manifest, which had previous retained the relative filenames.  This change massages the filenames listed in the parallel manifest so as to drop the relative pathing. 