### PR TITLE
Test that connections that should be permutations actually *are* permutations

### DIFF
--- a/examples/moving-geometry.py
+++ b/examples/moving-geometry.py
@@ -140,7 +140,7 @@ def run(actx, *,
     # a bit of work when reconstructing after a time step
 
     if group_factory_name == "warp_and_blend":
-        group_factory_cls = poly.PolynomialWarpAndBlendGroupFactory
+        group_factory_cls = poly.PolynomialWarpAndBlend2DRestrictingGroupFactory
 
         unit_nodes = mp.warp_and_blend_nodes(ambient_dim - 1, mesh_order)
     elif group_factory_name == "quadrature":

--- a/examples/plot-connectivity.py
+++ b/examples/plot-connectivity.py
@@ -20,10 +20,10 @@ def main():
 
     from meshmode.discretization import Discretization
     from meshmode.discretization.poly_element import \
-            PolynomialWarpAndBlendGroupFactory
+            PolynomialWarpAndBlend3DRestrictingGroupFactory
 
     discr = Discretization(
-            actx, mesh, PolynomialWarpAndBlendGroupFactory(order))
+            actx, mesh, PolynomialWarpAndBlend3DRestrictingGroupFactory(order))
 
     from meshmode.discretization.visualization import make_visualizer
     vis = make_visualizer(actx, discr, order)

--- a/examples/simple-dg.py
+++ b/examples/simple-dg.py
@@ -74,8 +74,9 @@ class DGDiscretization:
 
         from meshmode.discretization import Discretization
         from meshmode.discretization.poly_element import \
-                PolynomialWarpAndBlendGroupFactory
-        self.group_factory = PolynomialWarpAndBlendGroupFactory(order=order)
+                PolynomialWarpAndBlend2DRestrictingGroupFactory
+        self.group_factory = PolynomialWarpAndBlend2DRestrictingGroupFactory(
+                order=order)
         self.volume_discr = Discretization(actx, mesh, self.group_factory)
 
         assert self.volume_discr.dim == 2

--- a/experiments/refinement-playground.py
+++ b/experiments/refinement-playground.py
@@ -186,9 +186,10 @@ def refine_and_generate_chart_function(mesh, filename, function):
 
     from meshmode.discretization import Discretization
     from meshmode.discretization.poly_element import \
-            PolynomialWarpAndBlendGroupFactory
+            default_simplex_group_factory
     discr = Discretization(
-            cl_ctx, mesh, PolynomialWarpAndBlendGroupFactory(order))
+            cl_ctx, mesh, default_simplex_group_factory(
+                base_dim=mesh.dim, order=order))
     from meshmode.discretization.visualization import make_visualizer
     vis = make_visualizer(queue, discr, order)
     remove_if_exists("connectivity2.vtu")

--- a/meshmode/discretization/connection/direct.py
+++ b/meshmode/discretization/connection/direct.py
@@ -22,6 +22,7 @@ THE SOFTWARE.
 
 
 import numpy as np
+import numpy.linalg as la
 
 import loopy as lp
 from pytools import memoize_in, keyed_memoize_method
@@ -250,28 +251,33 @@ class DirectDiscretizationConnection(DiscretizationConnection):
         :class:`pyopencl.array.Array` containing the index subset.
         """
 
-        mat = actx.to_numpy(actx.thaw(
-                self._resample_matrix(actx, to_group_index, ibatch_index)))
-
-        nrows, ncols = mat.shape
-        result = np.zeros(nrows, dtype=self.to_discr.mesh.element_id_dtype)
+        ibatch = self.groups[to_group_index].batches[ibatch_index]
+        from_grp = self.from_discr.groups[ibatch.from_group_index]
 
         if tol_multiplier is None:
             tol_multiplier = 50
 
-        tol = np.finfo(mat.dtype).eps * tol_multiplier
+        tol = np.finfo(ibatch.result_unit_nodes.dtype).eps * tol_multiplier
 
-        for irow in range(nrows):
-            one_indices, = np.where(np.abs(mat[irow] - 1) < tol)
-            zero_indices, = np.where(np.abs(mat[irow]) < tol)
+        dim, ntgt_nodes = ibatch.result_unit_nodes.shape
+        if dim == 0:
+            assert ntgt_nodes == 1
+            return actx.freeze(actx.from_numpy(np.array([0], dtype=np.int32)))
 
-            if len(one_indices) != 1:
+        dist_vecs = (ibatch.result_unit_nodes.reshape(dim, -1, 1)
+                - from_grp.unit_nodes.reshape(dim, 1, -1))
+        dists = la.norm(dist_vecs, axis=0, ord=2)
+
+        result = np.zeros(ntgt_nodes, dtype=self.to_discr.mesh.element_id_dtype)
+
+        for irow in range(ntgt_nodes):
+            close_indices, = np.where(dists[irow] < tol)
+
+            if len(close_indices) != 1:
                 return None
-            if len(zero_indices) != ncols - 1:
-                return None
 
-            one_index, = one_indices
-            result[irow] = one_index
+            close_index, = close_indices
+            result[irow] = close_index
 
         return actx.freeze(actx.from_numpy(result))
 

--- a/meshmode/discretization/connection/opposite_face.py
+++ b/meshmode/discretization/connection/opposite_face.py
@@ -70,7 +70,6 @@ def _make_cross_face_batches(actx,
 
     dim = src_grp.dim
     _, nelements, ntgt_unit_nodes = tgt_bdry_nodes.shape
-    assert tgt_bdry_nodes.shape == src_bdry_nodes.shape
 
     # {{{ invert face map (using Gauss-Newton)
 
@@ -101,7 +100,9 @@ def _make_cross_face_batches(actx,
         one_deviation = np.abs(np.sum(intp_coeffs, axis=0) - 1)
         assert (one_deviation < tol).all(), np.max(one_deviation)
 
-        return np.einsum("fet,aef->aet", intp_coeffs, src_bdry_nodes)
+        mapped = np.einsum("fet,aef->aet", intp_coeffs, src_bdry_nodes)
+        assert tgt_bdry_nodes.shape == mapped.shape
+        return mapped
 
     def get_map_jacobian(unit_nodes):
         # unit_nodes: (dim, nelements, ntgt_unit_nodes)

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -667,7 +667,7 @@ def flat_norm(ary, ord=None) -> float:
         actx = ary.array_context
         return la.norm(
                 [
-                    actx.np.linalg.norm(actx.np.ravel(ary, order="A"), ord=ord)
+                    actx.np.linalg.norm(actx.np.ravel(subary, order="A"), ord=ord)
                     for _, subary in serialize_container(ary)],
                 ord=ord)
 

--- a/meshmode/mesh/generation.py
+++ b/meshmode/mesh/generation.py
@@ -1193,13 +1193,17 @@ def generate_warped_rect_mesh(dim, order, *, nelements_side=None,
 
     def m(x):
         result = np.empty_like(x)
-        result[0] = (
-                1.5*x[0] + np.cos(x[0])
-                + 0.1*np.sin(10*x[1]))
-        result[1] = (
-                0.05*np.cos(10*x[0])
-                + 1.3*x[1] + np.sin(x[1]))
-        if len(x) == 3:
+        if len(x) >= 2:
+            result[0] = (
+                    1.5*x[0] + np.cos(x[0])
+                    + 0.1*np.sin(10*x[1]))
+            result[1] = (
+                    0.05*np.cos(10*x[0])
+                    + 1.3*x[1] + np.sin(x[1]))
+        else:
+            result[0] = 1.5*x[0] + np.cos(x[0])
+
+        if len(x) >= 3:
             result[2] = x[2] + np.sin(x[0] / 2) / 2
         return result
 

--- a/meshmode/mesh/visualization.py
+++ b/meshmode/mesh/visualization.py
@@ -308,9 +308,10 @@ def vtk_visualize_mesh(actx, mesh, filename, vtk_high_order=True):
     order = max(mgrp.order for mgrp in mesh.groups)
 
     from meshmode.discretization.poly_element import \
-            PolynomialWarpAndBlendGroupFactory
+            default_simplex_group_factory
     from meshmode.discretization import Discretization
-    discr = Discretization(actx, mesh, PolynomialWarpAndBlendGroupFactory(order))
+    discr = Discretization(actx, mesh, default_simplex_group_factory(
+        mesh.dim, order))
 
     from meshmode.discretization.visualization import make_visualizer
     vis = make_visualizer(actx, discr, order, force_equidistant=vtk_high_order)

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ def main():
               # 2019.1 is required for the Firedrake CIs, which use an very specific
               # version of Loopy.
               "loopy>=2019.1",
-              
+
               "arraycontext",
 
               "recursivenodes",

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -35,7 +35,7 @@ from arraycontext import (
         with_container_arithmetic)
 
 from meshmode.discretization import Discretization
-from meshmode.discretization.poly_element import PolynomialWarpAndBlendGroupFactory
+from meshmode.discretization.poly_element import default_simplex_group_factory
 from meshmode.dof_array import DOFArray, flat_norm
 
 from pytools.obj_array import make_obj_array
@@ -67,7 +67,7 @@ def test_flatten_unflatten(actx_factory):
             a=(-0.5,)*ambient_dim,
             b=(+0.5,)*ambient_dim,
             n=(3,)*ambient_dim, order=1)
-    discr = Discretization(actx, mesh, PolynomialWarpAndBlendGroupFactory(3))
+    discr = Discretization(actx, mesh, default_simplex_group_factory(ambient_dim, 3))
     a = np.random.randn(discr.ndofs)
 
     from meshmode.dof_array import flatten, unflatten
@@ -99,7 +99,7 @@ def _get_test_containers(actx, ambient_dim=2):
             a=(-0.5,)*ambient_dim,
             b=(+0.5,)*ambient_dim,
             n=(3,)*ambient_dim, order=1)
-    discr = Discretization(actx, mesh, PolynomialWarpAndBlendGroupFactory(3))
+    discr = Discretization(actx, mesh, default_simplex_group_factory(ambient_dim, 3))
     x = thaw(discr.nodes()[0], actx)
 
     # pylint: disable=unexpected-keyword-arg, no-value-for-parameter

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,0 +1,128 @@
+__copyright__ = "Copyright (C) 2020 Andreas Kloeckner"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+from arraycontext import _acf  # noqa: F401
+from functools import partial
+import numpy as np  # noqa: F401
+import numpy.linalg as la  # noqa: F401
+
+import meshmode         # noqa: F401
+from arraycontext import (  # noqa
+        pytest_generate_tests_for_pyopencl_array_context
+        as pytest_generate_tests)
+
+from meshmode.mesh import SimplexElementGroup, TensorProductElementGroup
+from meshmode.discretization.poly_element import (
+        PolynomialWarpAndBlend2DRestrictingGroupFactory,
+        PolynomialWarpAndBlend3DRestrictingGroupFactory,
+        PolynomialEquidistantSimplexGroupFactory,
+        LegendreGaussLobattoTensorProductGroupFactory,
+        PolynomialRecursiveNodesGroupFactory,
+        )
+from meshmode.discretization import Discretization
+from meshmode.discretization.connection import FACE_RESTR_ALL
+import meshmode.mesh.generation as mgen
+
+import pytest
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def connection_is_permutation(actx, conn):
+    for i_tgrp, cgrp in enumerate(conn.groups):
+        for i_batch, batch in enumerate(cgrp.batches):
+            if not len(batch.from_element_indices):
+                continue
+
+            point_pick_indices = conn._resample_point_pick_indices(
+                    actx, i_tgrp, i_batch)
+
+            if point_pick_indices is None:
+                return False
+
+    return True
+
+
+@pytest.mark.parametrize("group_factory", [
+        "warp_and_blend",
+        PolynomialEquidistantSimplexGroupFactory,
+        LegendreGaussLobattoTensorProductGroupFactory,
+        partial(PolynomialRecursiveNodesGroupFactory, family="lgl"),
+        ])
+@pytest.mark.parametrize("dim", [2, 3])
+@pytest.mark.parametrize("order", [1, 2, 3, 4, 5])
+def test_bdry_restriction_is_permutation(actx_factory, group_factory, dim, order):
+    """Check that restriction to the boundary and opposite-face swap
+    for the element groups, orders and dimensions above is actually just
+    indirect access.
+    """
+    actx = actx_factory()
+
+    if group_factory == "warp_and_blend":
+        group_factory = {
+                2: PolynomialWarpAndBlend2DRestrictingGroupFactory,
+                3: PolynomialWarpAndBlend3DRestrictingGroupFactory,
+                }[dim]
+
+    if group_factory is LegendreGaussLobattoTensorProductGroupFactory:
+        group_cls = TensorProductElementGroup
+    else:
+        group_cls = SimplexElementGroup
+
+    mesh = mgen.generate_warped_rect_mesh(dim, order=order, nelements_side=5,
+            group_cls=group_cls)
+
+    vol_discr = Discretization(actx, mesh, group_factory(order))
+    from meshmode.discretization.connection import (
+            make_face_restriction, make_opposite_face_connection)
+    bdry_connection = make_face_restriction(
+            actx, vol_discr, group_factory(order),
+            FACE_RESTR_ALL)
+
+    assert connection_is_permutation(actx, bdry_connection)
+
+    is_lgl = group_factory is LegendreGaussLobattoTensorProductGroupFactory
+
+    # FIXME: This should pass unconditionally
+    should_pass = (
+            (dim == 3 and order < 2)
+            or (dim == 2 and not is_lgl)
+            or (dim == 2 and is_lgl and order < 4)
+            )
+
+    if should_pass:
+        opp_face = make_opposite_face_connection(actx, bdry_connection)
+        assert connection_is_permutation(actx, opp_face)
+    else:
+        pytest.xfail("https://github.com/inducer/meshmode/pull/105")
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        exec(sys.argv[1])
+    else:
+        from pytest import main
+        main([__file__])
+
+# vim: fdm=marker

--- a/test/test_mesh.py
+++ b/test/test_mesh.py
@@ -32,7 +32,7 @@ from arraycontext import (          # noqa: F401
 
 from meshmode.mesh import Mesh, SimplexElementGroup, TensorProductElementGroup
 from meshmode.discretization.poly_element import (
-        PolynomialWarpAndBlendGroupFactory,
+        default_simplex_group_factory,
         LegendreGaussLobattoTensorProductGroupFactory,
         )
 import meshmode.mesh.generation as mgen
@@ -62,9 +62,7 @@ def test_nonequal_rect_mesh_generation(actx_factory, dim, mesh_type,
             order=3, mesh_type=mesh_type)
 
     from meshmode.discretization import Discretization
-    from meshmode.discretization.poly_element import \
-            PolynomialWarpAndBlendGroupFactory as GroupFactory
-    discr = Discretization(actx, mesh, GroupFactory(3))
+    discr = Discretization(actx, mesh, default_simplex_group_factory(dim, 3))
 
     if visualize:
         from meshmode.discretization.visualization import make_visualizer
@@ -95,7 +93,7 @@ def test_box_mesh(actx_factory, visualize=False):
 
         actx = actx_factory()
         discr = Discretization(actx, mesh,
-                PolynomialWarpAndBlendGroupFactory(7))
+                default_simplex_group_factory(mesh.dim, 7))
 
         from meshmode.discretization.visualization import make_visualizer
         vis = make_visualizer(actx, discr, 7)
@@ -305,7 +303,7 @@ def test_merge_and_map(actx_factory, group_cls, visualize=False):
                 target_unit="MM",
                 )
 
-        discr_grp_factory = PolynomialWarpAndBlendGroupFactory(order)
+        discr_grp_factory = default_simplex_group_factory(base_dim=2, order=order)
     else:
         ambient_dim = 3
         mesh = mgen.generate_regular_rect_mesh(

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -34,7 +34,9 @@ from arraycontext import (  # noqa
 from meshmode.mesh import SimplexElementGroup, TensorProductElementGroup
 from meshmode.discretization.poly_element import (
         InterpolatoryQuadratureSimplexGroupFactory,
-        PolynomialWarpAndBlendGroupFactory,
+        default_simplex_group_factory,
+        PolynomialWarpAndBlend2DRestrictingGroupFactory,
+        PolynomialWarpAndBlend3DRestrictingGroupFactory,
         PolynomialRecursiveNodesGroupFactory,
         PolynomialEquidistantSimplexGroupFactory,
         LegendreGaussLobattoTensorProductGroupFactory
@@ -51,11 +53,24 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def normalize_group_factory(dim, grp_factory):
+    if grp_factory == "warp_and_blend":
+        return {
+            0: PolynomialWarpAndBlend2DRestrictingGroupFactory,
+            1: PolynomialWarpAndBlend2DRestrictingGroupFactory,
+            2: PolynomialWarpAndBlend2DRestrictingGroupFactory,
+            3: PolynomialWarpAndBlend3DRestrictingGroupFactory,
+            }[dim]
+    else:
+        assert not isinstance(grp_factory, str)
+        return grp_factory
+
+
 # {{{ convergence of boundary interpolation
 
 @pytest.mark.parametrize("group_factory", [
     InterpolatoryQuadratureSimplexGroupFactory,
-    PolynomialWarpAndBlendGroupFactory,
+    "warp_and_blend",
     partial(PolynomialRecursiveNodesGroupFactory, family="lgl"),
 
     # Redundant, no information gain.
@@ -86,6 +101,7 @@ def test_boundary_interpolation(actx_factory, group_factory, boundary_tag,
 
     actx = actx_factory()
 
+    group_factory = normalize_group_factory(dim, group_factory)
     if group_factory is LegendreGaussLobattoTensorProductGroupFactory:
         group_cls = TensorProductElementGroup
     else:
@@ -184,7 +200,8 @@ def test_boundary_interpolation(actx_factory, group_factory, boundary_tag,
 
 @pytest.mark.parametrize("group_factory", [
     InterpolatoryQuadratureSimplexGroupFactory,
-    PolynomialWarpAndBlendGroupFactory,
+    "warp_and_blend",
+    partial(PolynomialRecursiveNodesGroupFactory, family="lgl"),
     LegendreGaussLobattoTensorProductGroupFactory,
     ])
 @pytest.mark.parametrize(("mesh_name", "dim", "mesh_pars"), [
@@ -200,6 +217,8 @@ def test_all_faces_interpolation(actx_factory, group_factory,
         pytest.skip("tensor products not implemented on blobs")
 
     actx = actx_factory()
+
+    group_factory = normalize_group_factory(dim, group_factory)
 
     if group_factory is LegendreGaussLobattoTensorProductGroupFactory:
         group_cls = TensorProductElementGroup
@@ -306,7 +325,7 @@ def test_all_faces_interpolation(actx_factory, group_factory,
 
 @pytest.mark.parametrize("group_factory", [
     InterpolatoryQuadratureSimplexGroupFactory,
-    PolynomialWarpAndBlendGroupFactory,
+    "warp_and_blend",
     LegendreGaussLobattoTensorProductGroupFactory,
     ])
 @pytest.mark.parametrize(("mesh_name", "dim", "mesh_pars"), [
@@ -323,6 +342,8 @@ def test_opposite_face_interpolation(actx_factory, group_factory,
 
     logging.basicConfig(level=logging.INFO)
     actx = actx_factory()
+
+    group_factory = normalize_group_factory(dim, group_factory)
 
     if group_factory is LegendreGaussLobattoTensorProductGroupFactory:
         group_cls = TensorProductElementGroup
@@ -424,7 +445,7 @@ def test_orientation_3d(actx_factory, what, mesh_gen_func, visualize=False):
 
     from meshmode.discretization import Discretization
     discr = Discretization(actx, mesh,
-            PolynomialWarpAndBlendGroupFactory(3))
+            default_simplex_group_factory(base_dim=3, order=3))
 
     from pytential import bind, sym
 
@@ -478,7 +499,7 @@ def test_sanity_single_element(actx_factory, dim, mesh_order, group_cls,
     actx = actx_factory()
 
     if group_cls is SimplexElementGroup:
-        group_factory = PolynomialWarpAndBlendGroupFactory(mesh_order + 3)
+        group_factory = default_simplex_group_factory(dim, order=mesh_order + 3)
     elif group_cls is TensorProductElementGroup:
         group_factory = LegendreGaussLobattoTensorProductGroupFactory(mesh_order + 3)
     else:
@@ -787,7 +808,8 @@ def test_mesh_multiple_groups(actx_factory, ambient_dim, visualize=False):
         plt.savefig("test_mesh_multiple_groups_2d_elements.png", dpi=300)
 
     from meshmode.discretization import Discretization
-    discr = Discretization(actx, mesh, PolynomialWarpAndBlendGroupFactory(order))
+    grp_factory = default_simplex_group_factory(base_dim=ambient_dim, order=order)
+    discr = Discretization(actx, mesh, grp_factory)
 
     if visualize:
         group_id = discr.empty(actx, dtype=np.int32)
@@ -808,7 +830,7 @@ def test_mesh_multiple_groups(actx_factory, ambient_dim, visualize=False):
             check_connection)
     for boundary_tag in [BTAG_ALL, FACE_RESTR_INTERIOR, FACE_RESTR_ALL]:
         conn = make_face_restriction(actx, discr,
-                group_factory=PolynomialWarpAndBlendGroupFactory(order),
+                group_factory=grp_factory,
                 boundary_tag=boundary_tag,
                 per_face_groups=False)
         check_connection(actx, conn)

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -808,7 +808,12 @@ def test_mesh_multiple_groups(actx_factory, ambient_dim, visualize=False):
         plt.savefig("test_mesh_multiple_groups_2d_elements.png", dpi=300)
 
     from meshmode.discretization import Discretization
-    grp_factory = default_simplex_group_factory(base_dim=ambient_dim, order=order)
+
+    def grp_factory(mesh_el_group, index):
+        return default_simplex_group_factory(
+                base_dim=ambient_dim, order=order + 2 if index == 0 else order
+                )(mesh_el_group, index)
+
     discr = Discretization(actx, mesh, grp_factory)
 
     if visualize:

--- a/test/test_modal.py
+++ b/test/test_modal.py
@@ -40,7 +40,8 @@ from meshmode.discretization.poly_element import (
     # Simplex group factories
     ModalSimplexGroupFactory,
     InterpolatoryQuadratureSimplexGroupFactory,
-    PolynomialWarpAndBlendGroupFactory,
+    PolynomialWarpAndBlend2DRestrictingGroupFactory,
+    PolynomialWarpAndBlend3DRestrictingGroupFactory,
     PolynomialRecursiveNodesGroupFactory,
     PolynomialEquidistantSimplexGroupFactory,
     # Tensor product group factories
@@ -62,7 +63,7 @@ import pytest
 
 @pytest.mark.parametrize("nodal_group_factory", [
     InterpolatoryQuadratureSimplexGroupFactory,
-    PolynomialWarpAndBlendGroupFactory,
+    PolynomialWarpAndBlend2DRestrictingGroupFactory,
     partial(PolynomialRecursiveNodesGroupFactory, family="lgl"),
     PolynomialEquidistantSimplexGroupFactory,
     LegendreGaussLobattoTensorProductGroupFactory,
@@ -223,7 +224,7 @@ def test_quadrature_based_modal_connection_reverse(actx_factory, quad_group_fact
 
 @pytest.mark.parametrize("nodal_group_factory", [
     InterpolatoryQuadratureSimplexGroupFactory,
-    PolynomialWarpAndBlendGroupFactory,
+    "warp_and_blend",
     LegendreGaussLobattoTensorProductGroupFactory,
     ])
 @pytest.mark.parametrize(("dim", "mesh_pars"), [
@@ -232,6 +233,12 @@ def test_quadrature_based_modal_connection_reverse(actx_factory, quad_group_fact
     ])
 def test_modal_truncation(actx_factory, nodal_group_factory,
                           dim, mesh_pars):
+
+    if nodal_group_factory == "warp_and_blend":
+        nodal_group_factory = {
+                2: PolynomialWarpAndBlend2DRestrictingGroupFactory,
+                3: PolynomialWarpAndBlend3DRestrictingGroupFactory,
+                }[dim]
 
     if nodal_group_factory is LegendreGaussLobattoTensorProductGroupFactory:
         group_cls = TensorProductElementGroup

--- a/test/test_refinement.py
+++ b/test/test_refinement.py
@@ -39,7 +39,8 @@ import meshmode.mesh.generation as mgen
 from meshmode.mesh import SimplexElementGroup, TensorProductElementGroup
 from meshmode.discretization.poly_element import (
     InterpolatoryQuadratureSimplexGroupFactory,
-    PolynomialWarpAndBlendGroupFactory,
+    PolynomialWarpAndBlend2DRestrictingGroupFactory,
+    PolynomialWarpAndBlend3DRestrictingGroupFactory,
     PolynomialEquidistantSimplexGroupFactory,
     LegendreGaussLobattoTensorProductGroupFactory,
     GaussLegendreTensorProductGroupFactory,
@@ -160,11 +161,11 @@ def test_refinement(case_name, mesh_gen, flag_gen, num_generations):
 
 @pytest.mark.parametrize(("refiner_cls", "group_factory"), [
     (Refiner, InterpolatoryQuadratureSimplexGroupFactory),
-    (Refiner, PolynomialWarpAndBlendGroupFactory),
+    (Refiner, "warp_and_blend"),
     (Refiner, PolynomialEquidistantSimplexGroupFactory),
 
     (RefinerWithoutAdjacency, InterpolatoryQuadratureSimplexGroupFactory),
-    (RefinerWithoutAdjacency, PolynomialWarpAndBlendGroupFactory),
+    (RefinerWithoutAdjacency, "warp_and_blend"),
     (RefinerWithoutAdjacency, PolynomialEquidistantSimplexGroupFactory),
 
     (RefinerWithoutAdjacency, LegendreGaussLobattoTensorProductGroupFactory),
@@ -183,10 +184,18 @@ def test_refinement(case_name, mesh_gen, flag_gen, num_generations):
     #partial(random_refine_flags, 0.4)
     partial(even_refine_flags, 2)
 ])
-# test_refinement_connection(cl._csc, RefinerWithoutAdjacency, PolynomialWarpAndBlendGroupFactory, 'warp', 2, [4, 5, 6], 5, partial(even_refine_flags, 2))  # noqa: E501
+# test_refinement_connection(cl._csc, RefinerWithoutAdjacency, PolynomialWarpAndBlend2DRestrictingGroupFactory, 'warp', 2, [4, 5, 6], 5, partial(even_refine_flags, 2))  # noqa: E501
 def test_refinement_connection(
         actx_factory, refiner_cls, group_factory,
         mesh_name, dim, mesh_pars, mesh_order, refine_flags, visualize=False):
+
+    if group_factory == "warp_and_blend":
+        group_factory = {
+                1: PolynomialWarpAndBlend2DRestrictingGroupFactory,
+                2: PolynomialWarpAndBlend2DRestrictingGroupFactory,
+                3: PolynomialWarpAndBlend3DRestrictingGroupFactory,
+                }[dim]
+
     group_cls = group_factory.mesh_group_class
     if issubclass(group_cls, TensorProductElementGroup):
         if mesh_name in ["circle", "blob"]:

--- a/test/test_visualization.py
+++ b/test/test_visualization.py
@@ -33,7 +33,7 @@ from pytools.obj_array import make_obj_array
 
 from meshmode.mesh import SimplexElementGroup, TensorProductElementGroup
 from meshmode.discretization.poly_element import (
-        PolynomialWarpAndBlendGroupFactory,
+        default_simplex_group_factory,
         InterpolatoryQuadratureSimplexGroupFactory,
         LegendreGaussLobattoTensorProductGroupFactory,
         )
@@ -224,10 +224,9 @@ def test_copy_visualizer(actx_factory, ambient_dim, visualize=True):
             )
 
     from meshmode.discretization import Discretization
-    discr = Discretization(actx, mesh,
-            PolynomialWarpAndBlendGroupFactory(target_order))
-    translated_discr = Discretization(actx, translated_mesh,
-            PolynomialWarpAndBlendGroupFactory(target_order))
+    grp_factory = default_simplex_group_factory(ambient_dim, target_order)
+    discr = Discretization(actx, mesh, grp_factory)
+    translated_discr = Discretization(actx, translated_mesh, grp_factory)
 
     from meshmode.discretization.visualization import make_visualizer
     vis = make_visualizer(actx, discr, target_order, force_equidistant=True)


### PR DESCRIPTION
This is supposed to be a version of #105 that we can merge right away, plus a number of fixes that arose around that. For review, this PR is probably best viewed commit-by-commit. The commit messages provide a pretty good inventory of what's here.

Diff-wise, the biggest part of this is the (annoying, but IMO required) split of `PolynomialWarpAndBlendGroupFactory` into `PolynomialWarpAndBlend2DGroupFactory` and `PolynomialWarpAndBlend3DGroupFactory`. (The 2D WnB nodes are *not* equivalent to a restriction of the 3D nodes to a face, and we very much would like 2D el groups in 3D discretizations to be just that, so that the boundary extractions can be done by indirect addressing.)

- [ ] Post-merge, this needs a corresponding (and hopefully much smaller) change in grudge.

cc @nchristensen