### PR TITLE
_make_cross_face_batches: refactor into multiple functions, try matching nodes exactly before going to Gauss-Newton

### DIFF
--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -101,20 +101,8 @@ def test_bdry_restriction_is_permutation(actx_factory, group_factory, dim, order
 
     assert connection_is_permutation(actx, bdry_connection)
 
-    is_lgl = group_factory is LegendreGaussLobattoTensorProductGroupFactory
-
-    # FIXME: This should pass unconditionally
-    should_pass = (
-            (dim == 3 and order < 2)
-            or (dim == 2 and not is_lgl)
-            or (dim == 2 and is_lgl and order < 4)
-            )
-
-    if should_pass:
-        opp_face = make_opposite_face_connection(actx, bdry_connection)
-        assert connection_is_permutation(actx, opp_face)
-    else:
-        pytest.xfail("https://github.com/inducer/meshmode/pull/105")
+    opp_face = make_opposite_face_connection(actx, bdry_connection)
+    assert connection_is_permutation(actx, opp_face)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
While it doesn't actually solve the problem described in https://github.com/inducer/meshmode/pull/105#issuecomment-862003829, this should work around the main impact of #105: The DG examples no longer use matvecs to interpolate onto the boundary. This should help speed up larger-scale DG runs somewhat.

Draft because:
- [x] Should merge after #225, specifically https://github.com/inducer/meshmode/pull/225/commits/3d2f376ca69c1de83e13b9d7aaaa6c416b0ef07b (`test_mesh_multiple_groups`: Test inhomogeneous polynomial degree), because otherwise the Gauss-Newton code path would likely be untested.
- [x] After #225 is pulled into this, should update `test_bdry_restriction_is_permutation` to remove the `xfail`s. All the tests should then be passing: cbbca40

Post-merge:
- [ ] Update #105 as described in https://github.com/inducer/meshmode/pull/105#issuecomment-862703485

@majosm Could you review this? I know it'll likely have a little bit of conflict with #204, but `_make_cross_face_batches` was getting crazy long. Hopefully the conflicts won't be bad: the diff doesn't touch any of the actual functionality, it just shuffles function arguments around.

cc @nchristensen @matthiasdiener 