### PR TITLE
Teach meshmode about FEM program transformation

### DIFF
--- a/.ci/install-for-firedrake.sh
+++ b/.ci/install-for-firedrake.sh
@@ -21,9 +21,16 @@ pip install pybind11
 
 pip install pytest
 
-pip install -r /tmp/myreq.txt 
+pip install -r /tmp/myreq.txt
 
 # Context: https://github.com/OP2/PyOP2/pull/605
 python -m pip install --force-reinstall git+https://github.com/inducer/pytools.git
+
+# bring in up-to-date loopy
+pip uninstall -y loopy
+pip install "git+https://github.com/inducer/loopy.git#egg=loopy"
+
+# https://github.com/OP2/PyOP2/pull/627
+(cd /home/firedrake/firedrake/src/PyOP2 && git pull https://github.com/OP2/PyOP2.git e56d26f219e962cf9423fc84406a8a0656eb364f)
 
 pip install .

--- a/doc/array.rst
+++ b/doc/array.rst
@@ -7,3 +7,8 @@ Array Contexts
 ==============
 
 .. automodule:: meshmode.array_context
+
+Metadata for Program Transformation
+===================================
+
+.. automodule:: meshmode.transform_metadata

--- a/examples/from_firedrake.py
+++ b/examples/from_firedrake.py
@@ -22,7 +22,7 @@ THE SOFTWARE.
 
 import pyopencl as cl
 
-from arraycontext import PyOpenCLArrayContext
+from meshmode.array_context import PyOpenCLArrayContext
 
 
 # This example provides a brief template for bringing information in

--- a/examples/moving-geometry.py
+++ b/examples/moving-geometry.py
@@ -23,7 +23,8 @@ THE SOFTWARE.
 import numpy as np
 import pyopencl as cl
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from meshmode.array_context import PyOpenCLArrayContext
+from arraycontext import thaw
 
 from pytools import memoize_in, keyed_memoize_in
 from pytools.obj_array import make_obj_array

--- a/examples/plot-connectivity.py
+++ b/examples/plot-connectivity.py
@@ -1,7 +1,8 @@
 import numpy as np  # noqa
 import pyopencl as cl
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from meshmode.array_context import PyOpenCLArrayContext
+from arraycontext import thaw
 
 order = 4
 

--- a/examples/simple-dg.py
+++ b/examples/simple-dg.py
@@ -516,7 +516,7 @@ def main():
             # DOFArray would be nice?
             assert len(fields.u) == 1
             logger.info("[%05d] t %.5e / %.5e norm %.5e",
-                    istep, t, t_final, flat_norm(fields.u, 2))
+                    istep, t, t_final, actx.to_numpy(flat_norm(fields.u, 2)))
             vis.write_vtk_file("fld-wave-min-%04d.vtu" % istep, [
                 ("q", fields),
                 ])

--- a/examples/simple-dg.py
+++ b/examples/simple-dg.py
@@ -32,9 +32,10 @@ from pytools.obj_array import flat_obj_array, make_obj_array
 
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
 from meshmode.dof_array import DOFArray, flat_norm
+from meshmode.array_context import PyOpenCLArrayContext
 from arraycontext import (
         freeze, thaw,
-        PyOpenCLArrayContext, make_loopy_program,
+        make_loopy_program,
         ArrayContainer,
         map_array_container,
         with_container_arithmetic,
@@ -475,7 +476,7 @@ def main():
 
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
-    actx = PyOpenCLArrayContext(queue)
+    actx = PyOpenCLArrayContext(queue, force_device_scalars=True)
 
     nel_1d = 16
     from meshmode.mesh.generation import generate_regular_rect_mesh

--- a/examples/to_firedrake.py
+++ b/examples/to_firedrake.py
@@ -24,7 +24,8 @@ THE SOFTWARE.
 import numpy as np
 import pyopencl as cl
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from meshmode.array_context import PyOpenCLArrayContext
+from arraycontext import thaw
 
 
 # Nb: Some of the initial setup was adapted from meshmode/examplse/simple-dg.py

--- a/meshmode/__init__.py
+++ b/meshmode/__init__.py
@@ -43,8 +43,8 @@ def _acf():
     argument when running them from the command line.
     """
     import pyopencl as cl
-    from arraycontext import PyOpenCLArrayContext
+    from meshmode.array_context import PyOpenCLArrayContext
 
     context = cl._csc()
     queue = cl.CommandQueue(context)
-    return PyOpenCLArrayContext(queue)
+    return PyOpenCLArrayContext(queue, force_device_scalars=True)

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -200,11 +200,6 @@ class PyOpenCLArrayContext(PyOpenCLArrayContextBase):
     """
 
     def transform_loopy_program(self, t_unit):
-        try:
-            return self._loopy_transform_cache[t_unit]
-        except KeyError:
-            pass
-
         default_ep = t_unit.default_entrypoint
         options = default_ep.options
         if not (options.return_dict and options.no_numpy):
@@ -216,7 +211,6 @@ class PyOpenCLArrayContext(PyOpenCLArrayContextBase):
         transformed_t_unit = _transform_loopy_inner(t_unit)
 
         if transformed_t_unit is not None:
-            self._loopy_transform_cache[t_unit] = transformed_t_unit
             return t_unit
 
         warn("meshmode.array_context.PyOpenCLArrayContext."

--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -1,3 +1,7 @@
+"""
+.. autoclass:: PyOpenCLArrayContext
+"""
+
 __copyright__ = "Copyright (C) 2020 Andreas Kloeckner"
 
 __license__ = """
@@ -20,35 +24,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from arraycontext import (  # noqa: F401
-        ArrayContext,
-
-        CommonSubexpressionTag, FirstAxisIsElementsTag,
-
-        ArrayContainer,
-        is_array_container, is_array_container_type,
-        serialize_container, deserialize_container,
-        get_container_context, get_container_context_recursively,
-        with_container_arithmetic,
-        dataclass_array_container,
-
-        map_array_container, multimap_array_container,
-        rec_map_array_container, rec_multimap_array_container,
-        mapped_over_array_containers,
-        multimapped_over_array_containers,
-        thaw as _thaw, freeze,
-
-        PyOpenCLArrayContext,
-
-        make_loopy_program,
-
-        pytest_generate_tests_for_pyopencl_array_context
-        )
-
+import sys
 from warnings import warn
-warn("meshmode.array_context is deprecated. Import this functionality from "
-        "the arraycontext top-level package instead. This shim will remain working "
-        "until 2022.", DeprecationWarning, stacklevel=2)
+from arraycontext import PyOpenCLArrayContext as PyOpenCLArrayContextBase
+from arraycontext.pytest import (
+        _PytestPyOpenCLArrayContextFactoryWithClass,
+        register_pytest_array_context_factory)
 
 
 def thaw(actx, ary):
@@ -57,7 +38,273 @@ def thaw(actx, ary):
             "meshmode.array_context.thaw will continue to work until 2022.",
             DeprecationWarning, stacklevel=2)
 
+    from arraycontext import thaw as _thaw
     # /!\ arg order flipped
     return _thaw(ary, actx)
+
+
+# {{{ kernel transform function
+
+def _transform_loopy_inner(t_unit):
+    import loopy as lp
+    from meshmode.transform_metadata import FirstAxisIsElementsTag
+    from arraycontext.transform_metadata import ElementwiseMapKernelTag
+
+    from pymbolic.primitives import Subscript, Variable
+
+    default_ep = t_unit.default_entrypoint
+
+    # FIXME: Firedrake branch lacks kernel tags
+    kernel_tags = getattr(default_ep, "tags", ())
+
+    # {{{ FirstAxisIsElementsTag on kernel (compatibility)
+
+    if any(isinstance(tag, FirstAxisIsElementsTag) for tag in kernel_tags):
+        if (len(default_ep.instructions) != 1
+                or not isinstance(
+                    default_ep.instructions[0], lp.Assignment)):
+            raise ValueError("FirstAxisIsElementsTag may only be applied to "
+                    "a kernel if the kernel contains a single assignment.")
+
+        stmt, = default_ep.instructions
+
+        if not isinstance(stmt.assignee, Subscript):
+            raise ValueError("single assignment in FirstAxisIsElementsTag kernel "
+                    "must be a subscript")
+
+        output_name = stmt.assignee.aggregate.name
+        new_args = [
+                arg.tagged(FirstAxisIsElementsTag())
+                if arg.name == output_name else arg
+                for arg in default_ep.args]
+        default_ep = default_ep.copy(args=new_args)
+        t_unit = t_unit.with_kernel(default_ep)
+
+    # }}}
+
+    # {{{ ElementwiseMapKernelTag on kernel
+
+    if any(isinstance(tag, ElementwiseMapKernelTag) for tag in kernel_tags):
+        el_inames = []
+        dof_inames = []
+        for stmt in default_ep.instructions:
+            if isinstance(stmt, lp.MultiAssignmentBase):
+                for assignee in stmt.assignees:
+                    if not isinstance(assignee, Subscript):
+                        raise ValueError("assignees in "
+                                "ElementwiseMapKernelTag-tagged kernels must be "
+                                "subscripts")
+
+                    subscripts = assignee.index_tuple[:2]
+
+                    for i, subscript in enumerate(subscripts):
+                        if (not isinstance(subscript, Variable)
+                                or subscript.name not in default_ep.all_inames()):
+                            raise ValueError("subscripts in "
+                                    "ElementwiseMapKernelTag-tagged kernels must be "
+                                    "inames")
+
+                        if i == 0:
+                            el_inames.append(subscript.name)
+                        elif i == 1:
+                            dof_inames.append(subscript.name)
+
+        return _transform_with_element_and_dof_inames(t_unit, el_inames, dof_inames)
+
+    # }}}
+
+    # {{{ FirstAxisIsElementsTag on output variable
+
+    first_axis_el_args = [arg.name for arg in default_ep.args
+            if any(isinstance(tag, FirstAxisIsElementsTag) for tag in arg.tags)]
+
+    if first_axis_el_args:
+        el_inames = []
+        dof_inames = []
+
+        for stmt in default_ep.instructions:
+            if isinstance(stmt, lp.MultiAssignmentBase):
+                for assignee in stmt.assignees:
+                    if not isinstance(assignee, Subscript):
+                        raise ValueError("assignees in "
+                                "FirstAxisIsElementsTag-tagged kernels must be "
+                                "subscripts")
+
+                    if assignee.aggregate.name not in first_axis_el_args:
+                        continue
+
+                    subscripts = assignee.index_tuple[:2]
+
+                    for i, subscript in enumerate(subscripts):
+                        if (not isinstance(subscript, Variable)
+                                or subscript.name not in default_ep.all_inames()):
+                            raise ValueError("subscripts in "
+                                    "FirstAxisIsElementsTag-tagged kernels must be "
+                                    "inames")
+
+                        if i == 0:
+                            el_inames.append(subscript.name)
+                        elif i == 1:
+                            dof_inames.append(subscript.name)
+        return _transform_with_element_and_dof_inames(t_unit, el_inames, dof_inames)
+
+    # }}}
+
+    # {{{ element/dof iname tag
+
+    from meshmode.transform_metadata import \
+            ConcurrentElementInameTag, ConcurrentDOFInameTag
+    el_inames = [iname.name
+            for iname in default_ep.inames.values()
+            if ConcurrentElementInameTag() in iname.tags]
+    dof_inames = [iname.name
+            for iname in default_ep.inames.values()
+            if ConcurrentDOFInameTag() in iname.tags]
+
+    if el_inames:
+        return _transform_with_element_and_dof_inames(t_unit, el_inames, dof_inames)
+
+    # }}}
+
+    # *shrug* no idea how to transform this thing.
+    return None
+
+
+def _transform_with_element_and_dof_inames(t_unit, el_inames, dof_inames):
+    import loopy as lp
+
+    if set(el_inames) & set(dof_inames):
+        raise ValueError("Some inames are marked as both 'element' and 'dof' "
+                "inames. These must be disjoint.")
+
+    # Sorting ensures the same order of transformations is used every
+    # time; avoids accidentally generating cache misses or kernel
+    # hash conflicts.
+
+    for dof_iname in sorted(dof_inames):
+        t_unit = lp.split_iname(t_unit, dof_iname, 32, inner_tag="l.0")
+    for el_iname in sorted(el_inames):
+        t_unit = lp.tag_inames(t_unit, {el_iname: "g.0"})
+    return t_unit
+
+# }}}
+
+
+# {{{ pyopencl array context subclass
+
+class PyOpenCLArrayContext(PyOpenCLArrayContextBase):
+    """Extends :class:`arraycontext.PyOpenCLArrayContext` with knowledge about
+    program transformation for finite element programs.
+
+    See :mod:`meshmode.transform_metadata` for relevant metadata.
+    """
+
+    def transform_loopy_program(self, t_unit):
+        try:
+            return self._loopy_transform_cache[t_unit]
+        except KeyError:
+            pass
+
+        default_ep = t_unit.default_entrypoint
+        options = default_ep.options
+        if not (options.return_dict and options.no_numpy):
+            raise ValueError("Loopy kernel passed to call_loopy must "
+                    "have return_dict and no_numpy options set. "
+                    "Did you use arraycontext.make_loopy_program "
+                    "to create this kernel?")
+
+        transformed_t_unit = _transform_loopy_inner(t_unit)
+
+        if transformed_t_unit is not None:
+            self._loopy_transform_cache[t_unit] = transformed_t_unit
+            return t_unit
+
+        warn("meshmode.array_context.PyOpenCLArrayContext."
+                "transform_loopy_program fell back on "
+                "arraycontext.PyOpenCLArrayContext to find a transform for "
+                f"'{default_ep.name}'. "
+                "Please update your program to use metadata from "
+                "meshmode.transform_metadata. "
+                "This code path will stop working in 2022.",
+                DeprecationWarning, stacklevel=3)
+
+        return super().transform_loopy_program(t_unit)
+
+# }}}
+
+
+# {{{ pytest actx factory
+
+class PytestPyOpenCLArrayContextFactory(
+        _PytestPyOpenCLArrayContextFactoryWithClass):
+    actx_class = PyOpenCLArrayContext
+
+
+# deprecated
+class PytestPyOpenCLArrayContextFactoryWithHostScalars(
+        _PytestPyOpenCLArrayContextFactoryWithClass):
+    actx_class = PyOpenCLArrayContext
+    force_device_scalars = False
+
+
+register_pytest_array_context_factory("meshmode.pyopencl",
+        PytestPyOpenCLArrayContextFactory)
+register_pytest_array_context_factory("meshmode.pyopencl-deprecated",
+        PytestPyOpenCLArrayContextFactoryWithHostScalars)
+
+# }}}
+
+
+# {{{ handle move deprecation
+
+_actx_names = (
+        "ArrayContext",
+
+        "CommonSubexpressionTag",
+        "FirstAxisIsElementsTag",
+
+        "ArrayContainer",
+        "is_array_container", "is_array_container_type",
+        "serialize_container", "deserialize_container",
+        "get_container_context", "get_container_context_recursively",
+        "with_container_arithmetic",
+        "dataclass_array_container",
+
+        "map_array_container", "multimap_array_container",
+        "rec_map_array_container", "rec_multimap_array_container",
+        "mapped_over_array_containers",
+        "multimapped_over_array_containers",
+        "freeze",
+
+        "make_loopy_program",
+
+        "pytest_generate_tests_for_pyopencl_array_context"
+        )
+
+
+if sys.version_info >= (3, 7):
+    def __getattr__(name):
+        if name not in _actx_names:
+            raise AttributeError(name)
+
+        import arraycontext
+        result = getattr(arraycontext, name)
+
+        warn(f"meshmode.array_context.{name} is deprecated. "
+                f"Use arraycontext.{name} instead. "
+                f"meshmode.array_context.{name} will continue to work until 2022.",
+                DeprecationWarning, stacklevel=2)
+
+        return result
+else:
+    def _import_names():
+        import arraycontext
+        for name in _actx_names:
+            globals()[name] = getattr(arraycontext, name)
+
+    _import_names()
+
+# }}}
+
 
 # vim: foldmethod=marker

--- a/meshmode/discretization/connection/projection.py
+++ b/meshmode/discretization/connection/projection.py
@@ -28,7 +28,7 @@ import loopy as lp
 
 from arraycontext import (
         make_loopy_program, is_array_container, map_array_container)
-from arraycontext.metadata import FirstAxisIsElementsTag
+from meshmode.transform_metadata import FirstAxisIsElementsTag
 from meshmode.discretization.connection.direct import (
         DiscretizationConnection,
         DirectDiscretizationConnection)
@@ -134,7 +134,7 @@ class L2ProjectionInverseDiscretizationConnection(DiscretizationConnection):
         @memoize_in(actx, (L2ProjectionInverseDiscretizationConnection,
             "conn_projection_knl"))
         def kproj():
-            return make_loopy_program(
+            t_unit = make_loopy_program(
                 [
                     "{[iel_init]: 0 <= iel_init < n_to_elements}",
                     "{[idof_init]: 0 <= idof_init < n_to_nodes}",
@@ -168,6 +168,14 @@ class L2ProjectionInverseDiscretizationConnection(DiscretizationConnection):
                 ],
                 name="conn_projection_knl"
             )
+            from meshmode.transform_metadata import (
+                    ConcurrentElementInameTag, ConcurrentDOFInameTag)
+            return lp.tag_inames(t_unit, {
+                    "iel_init": ConcurrentElementInameTag(),
+                    "idof_init": ConcurrentDOFInameTag(),
+                    "iel": ConcurrentElementInameTag(),
+                    "ibasis": ConcurrentDOFInameTag(),
+                    })
 
         # compute weights on each refinement of the reference element
         weights = self._batch_weights(actx)

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -662,17 +662,17 @@ def flat_norm(ary, ord=None) -> float:
 
     from arraycontext import is_array_container
 
-    import numpy.linalg as la
+    from arraycontext.fake_numpy import _scalar_list_norm
     if isinstance(ary, DOFArray):
         actx = ary.array_context
-        return la.norm(
+        return _scalar_list_norm(
                 [
                     actx.np.linalg.norm(actx.np.ravel(subary, order="A"), ord=ord)
                     for _, subary in serialize_container(ary)],
                 ord=ord)
 
     elif is_array_container(ary):
-        return la.norm(
+        return _scalar_list_norm(
                 [flat_norm(subary, ord=ord)
                     for _, subary in serialize_container(ary)],
                 ord=ord)

--- a/meshmode/transform_metadata.py
+++ b/meshmode/transform_metadata.py
@@ -1,0 +1,59 @@
+"""
+.. autoclass:: FirstAxisIsElementsTag
+.. autoclass:: ConcurrentElementInameTag
+.. autoclass:: ConcurrentDOFInameTag
+"""
+
+__copyright__ = """
+Copyright (C) 2020-1 University of Illinois Board of Trustees
+"""
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+from pytools.tag import Tag
+
+
+class FirstAxisIsElementsTag(Tag):
+    """A tag that is applicable to array outputs indicating that the first
+    index corresponds to element indices. This suggests that the implementation
+    should set element indices as the outermost loop extent.
+
+    For convenience, this tag may *also* be applied to a kernel if that kernel
+    contains exactly one assignment, in which case the tag is considered
+    equivalent to being applied to the (single) output array argument.
+    """
+
+
+class ConcurrentElementInameTag(Tag):
+    """A tag applicable to an iname indicating that this iname is used to
+    iterate over elements in a discretization. States that no dependencies
+    exist between elements, i.e. that computations for all elements may be
+    performed concurrently.
+    """
+
+
+class ConcurrentDOFInameTag(Tag):
+    """A tag applicable to an iname indicating that this iname is used to
+    iterate over degrees of freedom (DOFs) within an element in a discretization.
+    States that no dependencies exist between output DOFs, i.e. that
+    computations for all DOFs within each element may be performed
+    concurrently.
+    """

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -24,10 +24,10 @@ from dataclasses import dataclass
 import pytest
 import numpy as np
 
-from arraycontext import _acf           # noqa: F401
-from arraycontext import (              # noqa: F401
-        pytest_generate_tests_for_pyopencl_array_context
-        as pytest_generate_tests)
+from meshmode.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
 
 from arraycontext import (
         thaw,

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 import pytest
 import numpy as np
 
+from meshmode import _acf  # noqa: F401
 from meshmode.array_context import PytestPyOpenCLArrayContextFactory
 from arraycontext import pytest_generate_tests_for_array_contexts
 pytest_generate_tests = pytest_generate_tests_for_array_contexts(

--- a/test/test_chained.py
+++ b/test/test_chained.py
@@ -392,7 +392,7 @@ def test_reversed_chained_connection(actx_factory, ndim, mesh_name):
 
     for n in mesh_sizes:
         h, error = run(n, order)
-        eoc.add_data_point(h, error)
+        eoc.add_data_point(h, actx.to_numpy(error))
 
     print(eoc)
 

--- a/test/test_chained.py
+++ b/test/test_chained.py
@@ -23,9 +23,10 @@ THE SOFTWARE.
 import numpy as np
 
 import pytest
-from arraycontext import (  # noqa
-        pytest_generate_tests_for_pyopencl_array_context
-        as pytest_generate_tests)
+from meshmode.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
 
 from arraycontext import thaw
 from meshmode.dof_array import flatten_to_numpy, flat_norm

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -20,15 +20,17 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from arraycontext import _acf  # noqa: F401
 from functools import partial
 import numpy as np  # noqa: F401
 import numpy.linalg as la  # noqa: F401
 
 import meshmode         # noqa: F401
-from arraycontext import (  # noqa
-        pytest_generate_tests_for_pyopencl_array_context
-        as pytest_generate_tests)
+
+from meshmode.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
+
 
 from meshmode.mesh import SimplexElementGroup, TensorProductElementGroup
 from meshmode.discretization.poly_element import (

--- a/test/test_discretization.py
+++ b/test/test_discretization.py
@@ -30,9 +30,10 @@ from meshmode.discretization.poly_element import (
         InterpolatoryQuadratureSimplexGroupFactory,
         )
 
-from arraycontext import (          # noqa: F401
-        pytest_generate_tests_for_pyopencl_array_context
-        as pytest_generate_tests)
+from meshmode.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
 
 
 def test_discr_nodes_caching(actx_factory):

--- a/test/test_firedrake_interop.py
+++ b/test/test_firedrake_interop.py
@@ -23,9 +23,10 @@ THE SOFTWARE.
 import numpy as np
 import pyopencl as cl
 
-from pyopencl.tools import (  # noqa
-        pytest_generate_tests_for_pyopencl
-        as pytest_generate_tests)
+from meshmode.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
 
 from arraycontext import PyOpenCLArrayContext
 

--- a/test/test_interop.py
+++ b/test/test_interop.py
@@ -24,10 +24,12 @@ THE SOFTWARE.
 import numpy as np
 import pytest
 
-from arraycontext import PyOpenCLArrayContext, thaw, _acf   # noqa: F401
-from arraycontext import (                                  # noqa: F401
-        pytest_generate_tests_for_pyopencl_array_context
-        as pytest_generate_tests)
+from arraycontext import thaw
+
+from meshmode.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
 from meshmode.dof_array import flat_norm
 
 import logging

--- a/test/test_mesh.py
+++ b/test/test_mesh.py
@@ -25,10 +25,10 @@ import numpy as np
 import numpy.linalg as la
 import pytest
 
-from arraycontext import _acf       # noqa: F401
-from arraycontext import (          # noqa: F401
-        pytest_generate_tests_for_pyopencl_array_context
-        as pytest_generate_tests)
+from meshmode.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
 
 from meshmode.mesh import Mesh, SimplexElementGroup, TensorProductElementGroup
 from meshmode.discretization.poly_element import (

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -187,7 +187,7 @@ def test_boundary_interpolation(actx_factory, group_factory, boundary_tag,
             assert mat_error < 1e-14, mat_error
 
         err = flat_norm(bdry_f-bdry_f_2, np.inf)
-        eoc_rec.add_data_point(h, err)
+        eoc_rec.add_data_point(h, actx.to_numpy(err))
 
     order_slack = 0.75 if mesh_name == "blob" else 0.5
     print(eoc_rec)
@@ -313,7 +313,7 @@ def test_all_faces_interpolation(actx_factory, group_factory,
             all_face_f_2 = all_face_f_2 + all_face_embedding(bdry_f)
 
         err = flat_norm(all_face_f-all_face_f_2, np.inf)
-        eoc_rec.add_data_point(h, err)
+        eoc_rec.add_data_point(h, actx.to_numpy(err))
 
     print(eoc_rec)
     assert (
@@ -422,7 +422,7 @@ def test_opposite_face_interpolation(actx_factory, group_factory,
         assert flat_norm(bdry_f_2-bdry_f_2_no_inp, np.inf) < 1e-14
 
         err = flat_norm(bdry_f-bdry_f_2, np.inf)
-        eoc_rec.add_data_point(h, err)
+        eoc_rec.add_data_point(h, actx.to_numpy(err))
 
     print(eoc_rec)
     assert (

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -26,12 +26,12 @@ import numpy as np
 import numpy.linalg as la
 
 import meshmode         # noqa: F401
-from arraycontext import (  # noqa
-        pytest_generate_tests_for_pyopencl_array_context
-        as pytest_generate_tests,
-        thaw)
+from arraycontext import thaw
 
-from arraycontext import _acf  # noqa: F401
+from meshmode.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
 
 from meshmode.mesh import SimplexElementGroup, TensorProductElementGroup
 from meshmode.discretization.poly_element import (

--- a/test/test_modal.py
+++ b/test/test_modal.py
@@ -309,7 +309,7 @@ def test_modal_truncation(actx_factory, nodal_group_factory,
         nodal_f_truncated = modal_to_nodal_conn(modal_f_truncated)
 
         err = flat_norm(nodal_f - nodal_f_truncated)
-        eoc_rec.add_data_point(h, err)
+        eoc_rec.add_data_point(h, actx.to_numpy(err))
         threshold_lower = 0.8*truncated_order
         threshold_upper = 1.2*truncated_order
 

--- a/test/test_modal.py
+++ b/test/test_modal.py
@@ -24,11 +24,11 @@ THE SOFTWARE.
 from functools import partial
 import numpy as np
 
-from arraycontext import thaw, _acf     # noqa: F401
-from arraycontext import (              # noqa: F401
-    pytest_generate_tests_for_pyopencl_array_context
-    as pytest_generate_tests
-    )
+from arraycontext import thaw
+from meshmode.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
 
 from meshmode.dof_array import DOFArray, flat_norm
 from meshmode.mesh import (

--- a/test/test_partition.py
+++ b/test/test_partition.py
@@ -28,10 +28,11 @@ import pyopencl as cl
 
 from meshmode.dof_array import flatten, unflatten, flat_norm
 
-from arraycontext import thaw, _acf         # noqa: F401
-from arraycontext import (                  # noqa: F401
-        pytest_generate_tests_for_pyopencl_array_context
-        as pytest_generate_tests)
+from arraycontext import thaw
+from meshmode.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
 
 from meshmode.discretization.poly_element import default_simplex_group_factory
 from meshmode.mesh import BTAG_ALL

--- a/test/test_refinement.py
+++ b/test/test_refinement.py
@@ -304,7 +304,7 @@ def test_refinement_connection(
                         ])
 
         err = flat_norm(f_interp - f_true, np.inf)
-        eoc_rec.add_data_point(h, err)
+        eoc_rec.add_data_point(h, actx.to_numpy(err))
 
     order_slack = 0.5
     if mesh_name == "blob" and order > 1:

--- a/test/test_refinement.py
+++ b/test/test_refinement.py
@@ -26,10 +26,12 @@ from functools import partial
 import numpy as np
 import pytest
 
-from arraycontext import thaw, _acf         # noqa: F401
-from arraycontext import (                  # noqa: F401
-        pytest_generate_tests_for_pyopencl_array_context
-        as pytest_generate_tests)
+from arraycontext import thaw
+
+from meshmode.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
 
 from meshmode.dof_array import flat_norm
 from meshmode.mesh.refinement.utils import check_nodal_adj_against_geometry

--- a/test/test_visualization.py
+++ b/test/test_visualization.py
@@ -39,10 +39,11 @@ from meshmode.discretization.poly_element import (
         )
 import meshmode.mesh.generation as mgen
 
-from arraycontext import thaw, _acf         # noqa: F401
-from arraycontext import (                  # noqa: F401
-        pytest_generate_tests_for_pyopencl_array_context
-        as pytest_generate_tests)
+from arraycontext import thaw
+from meshmode.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
 
 
 # {{{ test visualizer


### PR DESCRIPTION
This supersedes https://github.com/inducer/arraycontext/pull/29, in that it never made sense that `arraycontext` had to know anything about how to transform FEM-related programs. Together with https://github.com/inducer/arraycontext/pull/50, this PR fixes that.

This PR is probably best read commit-by-commit.

If you'd like to run this, you'll need https://github.com/inducer/loopy/pull/445 (already merged at the time of this writing).

Draft (but ready for review) because:
- [x] Needs https://github.com/inducer/arraycontext/pull/50
- [x] `requirements.txt` needs to be redangled.