### PR TITLE
Disable __bool__ on DOFArray

### DIFF
--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -175,7 +175,7 @@ class DOFArray:
 
     def __bool__(self):
         raise ValueError(
-                "The truth value of a DOFArray is ambiguous. "
+                "The truth value of a DOFArray is not well-defined. "
                 "Use actx.np.any(x) or actx.np.all(x)")
 
     def __len__(self):

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -173,6 +173,11 @@ class DOFArray:
 
     # {{{ sequence protocol
 
+    def __bool__(self):
+        raise ValueError(
+                "The truth value of a DOFArray is ambiguous. "
+                "Use actx.np.any(x) or actx.np.all(x)")
+
     def __len__(self):
         return len(self._data)
 


### PR DESCRIPTION
`DOFArray`s are automagically truthy because they implement `__len__`. Hopefully this wasn't used in too many places.

Requires inducer/arraycontext#66 (for the error message to be useful)