### PR TITLE
Overhaul facial adjacency + boundary tagging

### DIFF
--- a/doc/mesh.rst
+++ b/doc/mesh.rst
@@ -71,4 +71,9 @@ Mesh visualization
 
 .. automodule:: meshmode.mesh.visualization
 
+Mesh tools
+----------
+
+.. automodule:: meshmode.mesh.tools
+
 .. vim: sw=4

--- a/doc/mesh.rst
+++ b/doc/mesh.rst
@@ -2,6 +2,7 @@ Common infrastructure
 =====================
 
 .. automodule:: meshmode
+.. automodule:: meshmode.mesh.tools
 
 Mesh management
 ===============
@@ -70,10 +71,5 @@ Mesh visualization
 ------------------
 
 .. automodule:: meshmode.mesh.visualization
-
-Mesh tools
-----------
-
-.. automodule:: meshmode.mesh.tools
 
 .. vim: sw=4

--- a/meshmode/__init__.py
+++ b/meshmode/__init__.py
@@ -28,6 +28,7 @@ __doc__ = """
 """
 
 from builtins import FileExistsError  # noqa: F401
+from meshmode.mesh.tools import AffineMap  # noqa: F401
 
 
 class Error(RuntimeError):

--- a/meshmode/discretization/connection/opposite_face.py
+++ b/meshmode/discretization/connection/opposite_face.py
@@ -62,13 +62,11 @@ def _make_cross_face_batches(actx,
     def transform(aff_transform, x):
         mat, vec = aff_transform
         if mat is not None:
-            result = mat @ x
+            result = np.einsum("di,ien->den", mat, x)
         else:
             result = x
         if vec is not None:
             result = result + vec[:, np.newaxis, np.newaxis]
-        else:
-            result = x
         return result
 
     tgt_bdry_nodes = transform(tgt_aff_transform, np.array([

--- a/meshmode/discretization/connection/opposite_face.py
+++ b/meshmode/discretization/connection/opposite_face.py
@@ -419,9 +419,11 @@ def make_opposite_face_connection(actx, volume_to_bdry_conn):
         for i_tgt_grp in range(ngrps):
             vbc_tgt_grp_batches = volume_to_bdry_conn.groups[i_tgt_grp].batches
 
+            from meshmode.mesh import InteriorAdjacencyGroup
             adj_grps = [
                 adj for adj in vol_mesh.facial_adjacency_groups[i_tgt_grp]
-                if adj.ineighbor_group == i_src_grp]
+                if isinstance(adj, InteriorAdjacencyGroup)
+                and adj.ineighbor_group == i_src_grp]
 
             for adj in adj_grps:
                 for i_face_tgt in range(vol_mesh.groups[i_tgt_grp].nfaces):
@@ -580,7 +582,7 @@ def make_partition_connection(actx, *, local_bdry_conn, i_local_part,
 
             i_remote_vol_elems = rem_ipag.elements[indices]
             i_remote_faces = rem_ipag.element_faces[indices]
-            i_local_vol_elems = rem_ipag.partition_neighbors[indices]
+            i_local_vol_elems = rem_ipag.neighbors[indices]
             i_local_faces = rem_ipag.neighbor_faces[indices]
 
             del indices

--- a/meshmode/discretization/connection/opposite_face.py
+++ b/meshmode/discretization/connection/opposite_face.py
@@ -43,7 +43,7 @@ def _make_cross_face_batches(actx,
         tgt_bdry_discr, src_bdry_discr,
         i_tgt_grp, i_src_grp,
         tgt_bdry_element_indices, src_bdry_element_indices,
-        tgt_aff_transform=None, src_aff_transform=None):
+        tgt_aff_map=None, src_aff_map=None):
 
     if tgt_bdry_discr.dim == 0:
         return [InterpolationBatch(
@@ -55,18 +55,18 @@ def _make_cross_face_batches(actx,
 
     from meshmode.mesh.tools import AffineMap
 
-    if tgt_aff_transform is None:
-        tgt_aff_transform = AffineMap()
+    if tgt_aff_map is None:
+        tgt_aff_map = AffineMap()
 
-    if src_aff_transform is None:
-        src_aff_transform = AffineMap()
+    if src_aff_map is None:
+        src_aff_map = AffineMap()
 
-    tgt_bdry_nodes = tgt_aff_transform(np.array([
+    tgt_bdry_nodes = tgt_aff_map(np.array([
         thaw_to_numpy(actx, ary[i_tgt_grp])[tgt_bdry_element_indices]
         for ary in tgt_bdry_discr.nodes(cached=False)
         ]))
 
-    src_bdry_nodes = src_aff_transform(np.array([
+    src_bdry_nodes = src_aff_map(np.array([
         thaw_to_numpy(actx, ary[i_src_grp])[src_bdry_element_indices]
         for ary in src_bdry_discr.nodes(cached=False)
         ]))
@@ -503,7 +503,7 @@ def make_opposite_face_connection(actx, volume_to_bdry_conn):
                             i_tgt_grp, i_src_grp,
                             tgt_bdry_element_indices,
                             src_bdry_element_indices,
-                            tgt_aff_transform=adj.aff_transform)
+                            tgt_aff_map=adj.aff_map)
                     groups[i_tgt_grp].extend(batches)
 
     from meshmode.discretization.connection import (
@@ -612,7 +612,7 @@ def make_partition_connection(actx, *, local_bdry_conn, i_local_part,
                             i_local_grp, rem_ipag.igroup,
                             matched_local_bdry_el_indices,
                             matched_remote_bdry_el_indices,
-                            src_aff_transform=rem_ipag.aff_transform)
+                            src_aff_map=rem_ipag.aff_map)
 
                 part_batches[i_local_grp].extend(grp_batches)
 

--- a/meshmode/discretization/connection/opposite_face.py
+++ b/meshmode/discretization/connection/opposite_face.py
@@ -53,28 +53,20 @@ def _make_cross_face_batches(actx,
             result_unit_nodes=src_bdry_discr.groups[i_src_grp].unit_nodes,
             to_element_face=None)]
 
+    from meshmode.mesh.tools import AffineMap
+
     if tgt_aff_transform is None:
-        tgt_aff_transform = (None, None)
+        tgt_aff_transform = AffineMap()
 
     if src_aff_transform is None:
-        src_aff_transform = (None, None)
+        src_aff_transform = AffineMap()
 
-    def transform(aff_transform, x):
-        mat, vec = aff_transform
-        if mat is not None:
-            result = np.einsum("di,ien->den", mat, x)
-        else:
-            result = x
-        if vec is not None:
-            result = result + vec[:, np.newaxis, np.newaxis]
-        return result
-
-    tgt_bdry_nodes = transform(tgt_aff_transform, np.array([
+    tgt_bdry_nodes = tgt_aff_transform(np.array([
         thaw_to_numpy(actx, ary[i_tgt_grp])[tgt_bdry_element_indices]
         for ary in tgt_bdry_discr.nodes(cached=False)
         ]))
 
-    src_bdry_nodes = transform(src_aff_transform, np.array([
+    src_bdry_nodes = src_aff_transform(np.array([
         thaw_to_numpy(actx, ary[i_src_grp])[src_bdry_element_indices]
         for ary in src_bdry_discr.nodes(cached=False)
         ]))

--- a/meshmode/distributed.py
+++ b/meshmode/distributed.py
@@ -27,7 +27,10 @@ from dataclasses import dataclass
 import numpy as np
 from typing import List
 
-from meshmode.mesh import InterPartitionAdjacencyGroup
+from meshmode.mesh import (
+    InteriorAdjacencyGroup,
+    InterPartitionAdjacencyGroup
+)
 
 # This file needs to be importable without mpi4py. So don't be tempted to add
 # that import here--push it into individual functions instead.
@@ -293,7 +296,7 @@ def get_partition_by_pymetis(mesh, num_parts, *, connectivity="facial", **kwargs
                     + mesh.groups[fagrp.ineighbor_group].element_nr_base])
                 for fagrp_list in mesh.facial_adjacency_groups
                 for fagrp in fagrp_list
-                if fagrp.ineighbor_group is not None
+                if isinstance(fagrp, InteriorAdjacencyGroup)
                 ])
         sorted_neighbor_el_pairs = neighbor_el_pairs[
                 :, np.argsort(neighbor_el_pairs[0])]

--- a/meshmode/interop/firedrake/mesh.py
+++ b/meshmode/interop/firedrake/mesh.py
@@ -735,19 +735,20 @@ build_connection_from_firedrake`.
     with ProcessLogger(logger, "Flipping FacialAdjacencyGroups"):
         facial_adjacency_groups = []
         for igroup, fagrps in enumerate(unflipped_facial_adjacency_groups):
-            facial_adjacency_groups.append({})
-            for ineighbor_group, fagrp in fagrps.items():
+            facial_adjacency_groups.append([])
+            for fagrp in fagrps:
                 new_element_faces = flip_local_face_indices(fagrp.element_faces,
                                                             fagrp.elements)
                 new_neighbor_faces = flip_local_face_indices(fagrp.neighbor_faces,
                                                              fagrp.neighbors)
-                new_fagrp = FacialAdjacencyGroup(igroup=igroup,
-                                                 ineighbor_group=ineighbor_group,
-                                                 elements=fagrp.elements,
-                                                 element_faces=new_element_faces,
-                                                 neighbors=fagrp.neighbors,
-                                                 neighbor_faces=new_neighbor_faces)
-                facial_adjacency_groups[igroup][ineighbor_group] = new_fagrp
+                facial_adjacency_groups[igroup].append(
+                    FacialAdjacencyGroup(
+                        igroup=igroup,
+                        ineighbor_group=fagrp.ineighbor_group,
+                        elements=fagrp.elements,
+                        element_faces=new_element_faces,
+                        neighbors=fagrp.neighbors,
+                        neighbor_faces=new_neighbor_faces))
 
     return (Mesh(vertices, [group],
                  boundary_tags=bdy_tags,

--- a/meshmode/mesh/__init__.py
+++ b/meshmode/mesh/__init__.py
@@ -1335,6 +1335,11 @@ def _compute_facial_adjacency_from_vertices(
 
 def _merge_boundary_adjacency_groups(
         igrp, bdry_grps, merged_btag, element_id_dtype, face_id_dtype):
+    """
+    Create a new :class:`~meshmode.mesh.BoundaryAdjacencyGroup` containing all of
+    the entries from a list of existing boundary adjacency groups.
+    """
+
     if len(bdry_grps) == 0:
         return BoundaryAdjacencyGroup(
             igroup=igrp,
@@ -1367,6 +1372,13 @@ def _merge_boundary_adjacency_groups(
 
 def _complete_facial_adjacency_groups(
         facial_adjacency_groups, element_id_dtype, face_id_dtype):
+    """
+    Add :class:`~meshmode.mesh.BoundaryAdjacencyGroup` instances for
+    :class:`~meshmode.mesh.BTAG_NONE`, :class:`~meshmode.mesh.BTAG_ALL`, and
+    :class:`~meshmode.mesh.BTAG_REALLY_ALL` to a facial adjacency group list if
+    they are not present.
+    """
+
     completed_facial_adjacency_groups = facial_adjacency_groups.copy()
 
     for igrp, fagrp_list in enumerate(facial_adjacency_groups):

--- a/meshmode/mesh/__init__.py
+++ b/meshmode/mesh/__init__.py
@@ -1202,12 +1202,14 @@ def _compute_facial_adjacency_from_vertices(
     if not groups:
         return None
 
-    boundary_tags = set()
     if face_vertex_indices_to_tags is not None:
-        for tags in face_vertex_indices_to_tags.values():
-            if tags is not None:
-                for tag in tags:
-                    boundary_tags.add(tag)
+        boundary_tags = {
+            tag
+            for tags in face_vertex_indices_to_tags.values()
+            for tag in tags
+            if tags is not None}
+    else:
+        boundary_tags = set()
 
     boundary_tag_to_index = {tag: i for i, tag in enumerate(boundary_tags)}
 

--- a/meshmode/mesh/__init__.py
+++ b/meshmode/mesh/__init__.py
@@ -885,18 +885,14 @@ class Mesh(Record):
                 assert len(facial_adjacency_groups) == len(self.groups)
                 for fagrp_list in facial_adjacency_groups:
                     for fagrp in fagrp_list:
+                        nfagrp_elements, = fagrp.elements.shape
+                        assert fagrp.element_faces.dtype == self.face_id_dtype
+                        assert fagrp.element_faces.shape == (nfagrp_elements,)
                         if isinstance(fagrp, InteriorAdjacencyGroup):
-                            nfagrp_elements, = fagrp.elements.shape
-                            assert fagrp.element_faces.dtype == self.face_id_dtype
-                            assert fagrp.element_faces.shape == (nfagrp_elements,)
                             assert fagrp.neighbors.dtype == self.element_id_dtype
                             assert fagrp.neighbors.shape == (nfagrp_elements,)
                             assert fagrp.neighbor_faces.dtype == self.face_id_dtype
                             assert fagrp.neighbor_faces.shape == (nfagrp_elements,)
-                        else:
-                            nfagrp_elements, = fagrp.elements.shape
-                            assert fagrp.element_faces.dtype == self.face_id_dtype
-                            assert fagrp.element_faces.shape == (nfagrp_elements,)
 
             from meshmode.mesh.processing import \
                     test_volume_mesh_element_orientations

--- a/meshmode/mesh/__init__.py
+++ b/meshmode/mesh/__init__.py
@@ -440,7 +440,7 @@ class FacialAdjacencyGroup(Record):
     """
 
     def __init__(self, igroup, **kwargs):
-        Record.__init__(self, igroup=igroup, **kwargs)
+        super().__init__(igroup=igroup, **kwargs)
 
     def __eq__(self, other):
         return (
@@ -521,7 +521,7 @@ class InteriorAdjacencyGroup(FacialAdjacencyGroup):
         if aff_transform is None:
             aff_transform = (None, None)
 
-        FacialAdjacencyGroup.__init__(self,
+        super().__init__(
             # FacialAdjacencyGroup
             igroup=igroup,
             # InteriorAdjacencyGroup
@@ -683,7 +683,7 @@ class InterPartitionAdjacencyGroup(BoundaryAdjacencyGroup):
         if aff_transform is None:
             aff_transform = (None, None)
 
-        BoundaryAdjacencyGroup.__init__(self,
+        super().__init__(
             # FacialAdjacencyGroup
             igroup=igroup,
             # BoundaryAdjacencyGroup

--- a/meshmode/mesh/__init__.py
+++ b/meshmode/mesh/__init__.py
@@ -1567,12 +1567,10 @@ def check_bc_coverage(mesh, boundary_tags, incomplete_ok=False,
         else:
             all_btag = BTAG_REALLY_ALL
 
-        all_bdry_grps = [
+        all_bdry_grp, = [
             fagrp for fagrp in fagrp_list
             if isinstance(fagrp, BoundaryAdjacencyGroup)
             and fagrp.boundary_tag == all_btag]
-        assert len(all_bdry_grps) == 1
-        all_bdry_grp = all_bdry_grps[0]
 
         matching_bdry_grps = [
             fagrp for fagrp in fagrp_list

--- a/meshmode/mesh/__init__.py
+++ b/meshmode/mesh/__init__.py
@@ -1313,7 +1313,7 @@ def _compute_facial_adjacency_from_vertices(
                             element_faces=element_faces))
 
             is_untagged = ~np.any(belongs_to_bdry, axis=0)
-            if len(is_untagged) > 0:
+            if np.any(is_untagged):
                 grp_list.append(
                     BoundaryAdjacencyGroup(
                         igroup=igrp,

--- a/meshmode/mesh/__init__.py
+++ b/meshmode/mesh/__init__.py
@@ -505,8 +505,8 @@ class InteriorAdjacencyGroup(FacialAdjacencyGroup):
 
     .. attribute:: aff_map
 
-        An :class:`~meshmode.mesh.tools.AffineMap` representing the mapping from
-        the group's faces to their corresponding neighbor faces.
+        An :class:`~meshmode.AffineMap` representing the mapping from the group's
+        faces to their corresponding neighbor faces.
 
     .. automethod:: __eq__
     .. automethod:: __ne__
@@ -649,8 +649,8 @@ class InterPartitionAdjacencyGroup(BoundaryAdjacencyGroup):
 
     .. attribute:: aff_map
 
-        An :class:`~meshmode.mesh.tools.AffineMap` representing the mapping from
-        the group's faces to their corresponding neighbor faces.
+        An :class:`~meshmode.AffineMap` representing the mapping from the group's
+        faces to their corresponding neighbor faces.
 
     .. versionadded:: 2017.1
     """

--- a/meshmode/mesh/__init__.py
+++ b/meshmode/mesh/__init__.py
@@ -503,7 +503,7 @@ class InteriorAdjacencyGroup(FacialAdjacencyGroup):
         ``face_id_t [nfagrp_elements]``. ``neighbor_faces[i]`` gives the
         face index of the opposite face in element ``neighbors[i]``
 
-    .. attribute:: aff_transform
+    .. attribute:: aff_map
 
         An :class:`~meshmode.mesh.tools.AffineMap` representing the mapping from
         the group's faces to their corresponding neighbor faces.
@@ -516,10 +516,10 @@ class InteriorAdjacencyGroup(FacialAdjacencyGroup):
             ineighbor_group,
             elements, element_faces,
             neighbors, neighbor_faces,
-            aff_transform=None,
+            aff_map=None,
             **kwargs):
-        if aff_transform is None:
-            aff_transform = AffineMap()
+        if aff_map is None:
+            aff_map = AffineMap()
 
         super().__init__(
             # FacialAdjacencyGroup
@@ -528,7 +528,7 @@ class InteriorAdjacencyGroup(FacialAdjacencyGroup):
             ineighbor_group=ineighbor_group,
             elements=elements, element_faces=element_faces,
             neighbors=neighbors, neighbor_faces=neighbor_faces,
-            aff_transform=aff_transform,
+            aff_map=aff_map,
             **kwargs)
 
     def __eq__(self, other):
@@ -539,7 +539,7 @@ class InteriorAdjacencyGroup(FacialAdjacencyGroup):
             and np.array_equal(self.element_faces, other.element_faces)
             and np.array_equal(self.neighbors, other.neighbors)
             and np.array_equal(self.neighbor_faces, other.neighbor_faces)
-            and self.aff_transform == other.aff_transform)
+            and self.aff_map == other.aff_map)
 
     def as_python(self):
         if type(self) != InteriorAdjacencyGroup:
@@ -551,7 +551,7 @@ class InteriorAdjacencyGroup(FacialAdjacencyGroup):
             element_faces=_numpy_array_as_python(self.element_faces),
             neighbors=_numpy_array_as_python(self.neighbors),
             neighbor_faces=_numpy_array_as_python(self.neighbor_faces),
-            aff_transform=_affine_map_as_python(self.aff_transform))
+            aff_map=_affine_map_as_python(self.aff_map))
 
 # }}}
 
@@ -647,7 +647,7 @@ class InterPartitionAdjacencyGroup(BoundaryAdjacencyGroup):
         neighboring partition of the face connected to
         ``element_id_dtype elements[i]``
 
-    .. attribute:: aff_transform
+    .. attribute:: aff_map
 
         An :class:`~meshmode.mesh.tools.AffineMap` representing the mapping from
         the group's faces to their corresponding neighbor faces.
@@ -659,10 +659,10 @@ class InterPartitionAdjacencyGroup(BoundaryAdjacencyGroup):
             elements, element_faces,
             ineighbor_partition,
             neighbors, neighbor_faces,
-            aff_transform=None,
+            aff_map=None,
             **kwargs):
-        if aff_transform is None:
-            aff_transform = AffineMap()
+        if aff_map is None:
+            aff_map = AffineMap()
 
         super().__init__(
             # FacialAdjacencyGroup
@@ -673,7 +673,7 @@ class InterPartitionAdjacencyGroup(BoundaryAdjacencyGroup):
             # InterPartitionAdjacencyGroup
             ineighbor_partition=ineighbor_partition,
             neighbors=neighbors, neighbor_faces=neighbor_faces,
-            aff_transform=aff_transform,
+            aff_map=aff_map,
             **kwargs)
 
     def __eq__(self, other):
@@ -682,7 +682,7 @@ class InterPartitionAdjacencyGroup(BoundaryAdjacencyGroup):
             and self.ineighbor_partition == other.ineighbor_partition
             and np.array_equal(self.neighbors, other.neighbors)
             and np.array_equal(self.neighbor_faces, other.neighbor_faces)
-            and self.aff_transform == other.aff_transform)
+            and self.aff_map == other.aff_map)
 
     def as_python(self):
         if type(self) != InterPartitionAdjacencyGroup:
@@ -695,7 +695,7 @@ class InterPartitionAdjacencyGroup(BoundaryAdjacencyGroup):
             ineighbor_partition=self.ineighbor_partition,
             neighbors=_numpy_array_as_python(self.neighbors),
             neighbor_faces=_numpy_array_as_python(self.neighbor_faces),
-            aff_transform=_affine_map_as_python(self.aff_transform))
+            aff_map=_affine_map_as_python(self.aff_map))
 
 # }}}
 

--- a/meshmode/mesh/__init__.py
+++ b/meshmode/mesh/__init__.py
@@ -1284,9 +1284,9 @@ def _compute_facial_adjacency_from_vertices(
 
         has_bdry = not np.all(face_has_neighbor)
         if has_bdry:
-            bdry_indices = np.where(~face_has_neighbor)
-            bdry_element_faces = bdry_indices[0].astype(face_id_dtype)
-            bdry_elements = bdry_indices[1].astype(element_id_dtype)
+            bdry_element_faces, bdry_elements = np.where(~face_has_neighbor)
+            bdry_element_faces = bdry_element_faces.astype(face_id_dtype)
+            bdry_elements = bdry_elements.astype(element_id_dtype)
             belongs_to_bdry = np.full(
                 (len(boundary_tags), len(bdry_elements)), False)
 

--- a/meshmode/mesh/generation.py
+++ b/meshmode/mesh/generation.py
@@ -1131,12 +1131,9 @@ def generate_box_mesh(axis_coords, order=1, coord_dtype=np.float64,
                         face_vertex_indices_to_tags.setdefault(key, []).append(tag)
 
     if boundary_tags:
-        from meshmode.mesh import (
-                _compute_facial_adjacency_from_vertices, BTAG_ALL, BTAG_REALLY_ALL)
-        boundary_tags.extend([BTAG_ALL, BTAG_REALLY_ALL])
+        from meshmode.mesh import _compute_facial_adjacency_from_vertices
         facial_adjacency_groups = _compute_facial_adjacency_from_vertices(
-                [grp], boundary_tags, np.int32, np.int8,
-                face_vertex_indices_to_tags)
+                [grp], np.int32, np.int8, face_vertex_indices_to_tags)
     else:
         facial_adjacency_groups = None
 
@@ -1145,7 +1142,7 @@ def generate_box_mesh(axis_coords, order=1, coord_dtype=np.float64,
     from meshmode.mesh import Mesh
     return Mesh(vertices, [grp],
             facial_adjacency_groups=facial_adjacency_groups,
-            is_conforming=True, boundary_tags=boundary_tags)
+            is_conforming=True)
 
 # }}}
 

--- a/meshmode/mesh/io.py
+++ b/meshmode/mesh/io.py
@@ -244,26 +244,17 @@ class GmshMeshReceiver(GmshMeshReceiverBase):
         else:
             is_conforming = mesh_bulk_dim < 3
 
-        # construct boundary tags for mesh
-        from meshmode.mesh import BTAG_ALL, BTAG_REALLY_ALL
-        boundary_tags = [BTAG_ALL, BTAG_REALLY_ALL]
-        if self.tags:
-            boundary_tags += [tag for tag, dim in self.tags if
-                              dim == mesh_bulk_dim-1]
-
         # compute facial adjacency for Mesh if there is tag information
         facial_adjacency_groups = None
         if is_conforming and self.tags:
             from meshmode.mesh import _compute_facial_adjacency_from_vertices
             facial_adjacency_groups = _compute_facial_adjacency_from_vertices(
-                    groups, boundary_tags, np.int32, np.int8,
-                    face_vertex_indices_to_tags)
+                    groups, np.int32, np.int8, face_vertex_indices_to_tags)
 
         return Mesh(
                 vertices, groups,
                 is_conforming=is_conforming,
                 facial_adjacency_groups=facial_adjacency_groups,
-                boundary_tags=boundary_tags,
                 **self.mesh_construction_kwargs)
 
 # }}}
@@ -410,12 +401,6 @@ def to_json(mesh):
     """Return a JSON-able Python data structure for *mesh*. The structure directly
     reflects the :class:`meshmode.mesh.Mesh` data structure."""
 
-    def btag_to_json(btag):
-        if isinstance(btag, str):
-            return btag
-        else:
-            return btag.__name__
-
     def group_to_json(group):
         return {
             "type": type(group).__name__,
@@ -454,11 +439,6 @@ def to_json(mesh):
         "nodal_adjacency": nodal_adjacency_to_json(mesh),
         # not yet implemented
         "facial_adjacency_groups": None,
-        "boundary_tags": [btag_to_json(btag) for btag in mesh.boundary_tags],
-        "btag_to_index": {
-            btag_to_json(btag): value
-
-            for btag, value in mesh.btag_to_index.items()},
         "is_conforming": mesh.is_conforming,
         }
 

--- a/meshmode/mesh/processing.py
+++ b/meshmode/mesh/processing.py
@@ -202,10 +202,12 @@ def _get_connected_partitions(
                         + elem_base_i] >= 0
             neighbors_are_nonlocal = global_elem_to_part_elem[facial_adj.neighbors
                         + elem_base_j] < 0
-            adj_indices, = np.where(elements_are_local & neighbors_are_nonlocal)
 
             connected_parts.update(
-                part_per_element[facial_adj.neighbors[adj_indices] + elem_base_j])
+                part_per_element[
+                    facial_adj.neighbors[
+                        elements_are_local & neighbors_are_nonlocal]
+                    + elem_base_j])
 
     return connected_parts
 

--- a/meshmode/mesh/processing.py
+++ b/meshmode/mesh/processing.py
@@ -944,20 +944,8 @@ def affine_map(mesh,
     if b is not None and b.shape != (mesh.ambient_dim,):
         raise ValueError(f"b has shape '{b.shape}' for a {mesh.ambient_dim}d mesh")
 
-    if b is not None:
-        b = b.reshape(-1, 1)
-
-    def f(x):
-        z = x
-        if A is not None:
-            z = A @ z
-
-        if b is not None:
-            z = z + b
-
-        return z
-
-    return map_mesh(mesh, f)
+    from meshmode.mesh.tools import AffineMap
+    return map_mesh(mesh, AffineMap(A, b))
 
 
 def _get_rotation_matrix_from_angle_and_axis(theta, axis):

--- a/meshmode/mesh/processing.py
+++ b/meshmode/mesh/processing.py
@@ -278,7 +278,7 @@ def _create_local_to_local_adjacency_groups(mesh, global_elem_to_part_elem,
                         element_faces=element_faces,
                         neighbors=neighbors,
                         neighbor_faces=neighbor_faces,
-                        aff_transform=facial_adj.aff_transform))
+                        aff_map=facial_adj.aff_map))
 
     return local_to_local_adjacency_groups
 
@@ -358,7 +358,7 @@ def _create_nonlocal_adjacency_groups(
                             element_faces=element_faces,
                             neighbors=neighbors,
                             neighbor_faces=neighbor_faces,
-                            aff_transform=facial_adj.aff_transform))
+                            aff_map=facial_adj.aff_map))
 
     return nonlocal_adj_groups
 

--- a/meshmode/mesh/processing.py
+++ b/meshmode/mesh/processing.py
@@ -437,12 +437,10 @@ def partition_mesh(mesh, part_per_element, part_num):
     assert len(part_per_element) == mesh.nelements, (
         "part_per_element must have shape (mesh.nelements,)")
 
-    part_per_element_np = np.array(part_per_element)
-
     # Contains the indices of the elements requested.
-    queried_elems, = np.where(part_per_element_np == part_num)
+    queried_elems, = np.where(part_per_element == part_num)
 
-    global_elem_to_part_elem = _compute_global_elem_to_part_elem(part_per_element_np,
+    global_elem_to_part_elem = _compute_global_elem_to_part_elem(part_per_element,
                 {part_num}, mesh.element_id_dtype)
 
     # Create new mesh groups that mimic the original mesh's groups but only contain
@@ -461,14 +459,14 @@ def partition_mesh(mesh, part_per_element, part_num):
         el_nr += grp.nelements
 
     connected_parts = _get_connected_partitions(
-        mesh, part_per_element_np, global_elem_to_part_elem)
+        mesh, part_per_element, global_elem_to_part_elem)
 
     local_to_local_adj_groups = _create_local_to_local_adjacency_groups(
                 mesh, global_elem_to_part_elem, part_mesh_groups,
                 global_group_to_part_group, part_mesh_group_elem_base)
 
     nonlocal_adj_groups = _create_nonlocal_adjacency_groups(
-                mesh, part_per_element_np, global_elem_to_part_elem,
+                mesh, part_per_element, global_elem_to_part_elem,
                 part_mesh_groups, global_group_to_part_group,
                 part_mesh_group_elem_base, connected_parts)
 

--- a/meshmode/mesh/processing.py
+++ b/meshmode/mesh/processing.py
@@ -213,7 +213,7 @@ def _create_local_to_local_adjacency_groups(mesh, global_elem_to_part_elem,
             neighbors_are_local = global_elem_to_part_elem[facial_adj.neighbors
                         + elem_base_j] >= 0
 
-            adj_indices = np.where(elements_are_local & neighbors_are_local)[0]
+            adj_indices, = np.where(elements_are_local & neighbors_are_local)
 
             if len(adj_indices) > 0:
                 part_elem_base_i = part_mesh_group_elem_base[i_part_grp]
@@ -329,7 +329,7 @@ def _collect_nonlocal_adjacency_data(mesh, part_per_elem, global_elem_to_part_el
                         + elem_base_i] >= 0
             neighbors_are_nonlocal = global_elem_to_part_elem[facial_adj.neighbors
                         + elem_base_j] < 0
-            adj_indices = np.where(elements_are_local & neighbors_are_nonlocal)[0]
+            adj_indices, = np.where(elements_are_local & neighbors_are_nonlocal)
 
             if len(adj_indices) > 0:
                 part_elem_base_i = part_mesh_group_elem_base[i_part_grp]
@@ -409,8 +409,8 @@ def _collect_bdry_data(mesh, global_elem_to_part_elem, part_mesh_groups,
         for bdry_grp in bdry_grps:
             elem_base = mesh.groups[igrp].element_nr_base
 
-            adj_indices = np.where(global_elem_to_part_elem[bdry_grp.elements
-                        + elem_base] >= 0)[0]
+            adj_indices, = np.where(global_elem_to_part_elem[bdry_grp.elements
+                        + elem_base] >= 0)
 
             if len(adj_indices) > 0:
                 part_elem_base = part_mesh_group_elem_base[i_part_grp]
@@ -509,7 +509,7 @@ def partition_mesh(mesh, part_per_element, part_num):
         "part_per_element must have shape (mesh.nelements,)")
 
     # Contains the indices of the elements requested.
-    queried_elems = np.where(np.array(part_per_element) == part_num)[0]
+    queried_elems, = np.where(np.array(part_per_element) == part_num)
 
     global_elem_to_part_elem = _compute_global_elem_to_part_elem(part_per_element,
                 {part_num}, mesh.element_id_dtype)

--- a/meshmode/mesh/tools.py
+++ b/meshmode/mesh/tools.py
@@ -27,6 +27,11 @@ from modepy.tools import hypercube_submesh
 from pytools.spatial_btree import SpatialBinaryTreeBucket
 from pytools import MovedFunctionDeprecationWrapper
 
+__doc__ = """
+
+.. autoclass:: AffineMap
+"""
+
 
 # {{{ make_element_lookup_tree
 
@@ -113,32 +118,83 @@ def rand_rotation_matrix(ambient_dim, deflection=1.0, randnums=None):
 # {{{ AffineMap
 
 class AffineMap:
-    """An affine map ``A@x+b``represented by a matrix *A* and an offset vector *b*.
+    """An affine map ``A@x+b`` represented by a matrix *A* and an offset vector *b*.
 
     .. attribute:: matrix
 
-        A :class:`numpy.ndarray` representing the matrix *A*.
+        A :class:`numpy.ndarray` representing the matrix *A*, or *None*.
 
     .. attribute:: offset
 
-        A :class:`numpy.ndarray` representing the vector *b*.
+        A :class:`numpy.ndarray` representing the vector *b*, or *None*.
 
-    .. autofunction:: inverted
-    .. autofunction:: __call__
+    .. automethod:: __init__
+    .. automethod:: inverted
+    .. automethod:: __call__
+    .. automethod:: __eq__
+    .. automethod:: __ne__
     """
 
-    def __init__(self, matrix, offset):
-        self.matrix = matrix
-        self.offset = offset
+    def __init__(self, matrix=None, offset=None):
+        """
+        :arg matrix: A :class:`numpy.ndarray` (or something convertible to one),
+            or *None*.
+        :arg offset: A :class:`numpy.ndarray` (or something convertible to one),
+            or *None*.
+        """
+        def promote_to_numpy(array):
+            if array is not None:
+                if isinstance(array, np.ndarray):
+                    return array
+                else:
+                    return np.array(array)
+            else:
+                return None
+
+        self.matrix = promote_to_numpy(matrix)
+        self.offset = promote_to_numpy(offset)
 
     def inverted(self):
-        return AffineMap(la.inv(self.matrix), -la.solve(self.matrix, self.offset))
+        """Return the inverse affine map."""
+        if self.matrix is not None:
+            inv_matrix = la.inv(self.matrix)
+            if self.offset is not None:
+                inv_offset = -inv_matrix @ self.offset
+            else:
+                inv_offset = None
+        else:
+            inv_matrix = None
+            if self.offset is not None:
+                inv_offset = -self.offset  # pylint: disable=E1130
+            else:
+                inv_offset = None
+        return AffineMap(inv_matrix, inv_offset)
 
     def __call__(self, vecs):
         """Apply the affine map to an array *vecs* whose first axis
         length matches ``matrix.shape[1]``.
         """
-        return (np.dot(self.matrix, vecs).T + self.offset).T
+        if self.matrix is not None:
+            result = np.einsum("ij,j...->i...", self.matrix, vecs)
+        else:
+            result = vecs.copy()
+        if self.offset is not None:
+            result += self.offset.reshape(-1, *((1,) * (vecs.ndim-1)))
+        return result
+
+    def __eq__(self, other):
+        def component_equal(array1, array2):
+            if isinstance(array1, np.ndarray) and isinstance(array2, np.ndarray):
+                return np.array_equal(array1, array2)
+            else:
+                return array1 == array2
+
+        return (
+            component_equal(self.matrix, other.matrix)
+            and component_equal(self.offset, other.offset))
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 # }}}
 

--- a/meshmode/mesh/tools.py
+++ b/meshmode/mesh/tools.py
@@ -28,6 +28,7 @@ from pytools.spatial_btree import SpatialBinaryTreeBucket
 from pytools import MovedFunctionDeprecationWrapper
 
 __doc__ = """
+.. currentmodule:: meshmode
 
 .. autoclass:: AffineMap
 """

--- a/test/test_mesh.py
+++ b/test/test_mesh.py
@@ -521,9 +521,6 @@ def test_boundary_tags():
     from meshmode.mesh.io import read_gmsh
     # ensure tags are read in
     mesh = read_gmsh("annulus.msh")
-    if not {"outer_bdy", "inner_bdy"} <= set(mesh.boundary_tags):
-        print("Mesh boundary tags:", mesh.boundary_tags)
-        raise ValueError("Tags not saved by mesh")
 
     # correct answers
     num_on_outer_bdy = 26
@@ -532,18 +529,15 @@ def test_boundary_tags():
     # check how many elements are marked on each boundary
     num_marked_outer_bdy = 0
     num_marked_inner_bdy = 0
-    outer_btag_bit = mesh.boundary_tag_bit("outer_bdy")
-    inner_btag_bit = mesh.boundary_tag_bit("inner_bdy")
     for igrp in range(len(mesh.groups)):
         bdry_fagrps = [
             fagrp for fagrp in mesh.facial_adjacency_groups[igrp]
             if isinstance(fagrp, BoundaryAdjacencyGroup)]
         for bdry_fagrp in bdry_fagrps:
-            for flags in bdry_fagrp.flags:
-                if flags & outer_btag_bit:
-                    num_marked_outer_bdy += 1
-                if flags & inner_btag_bit:
-                    num_marked_inner_bdy += 1
+            if bdry_fagrp.boundary_tag == "outer_bdy":
+                num_marked_outer_bdy += len(bdry_fagrp.elements)
+            if bdry_fagrp.boundary_tag == "inner_bdy":
+                num_marked_inner_bdy += len(bdry_fagrp.elements)
 
     # raise errors if wrong number of elements marked
     if num_marked_inner_bdy != num_on_inner_bdy:
@@ -627,18 +621,15 @@ def test_box_boundary_tags(dim, nelem, mesh_type, group_cls, visualize=False):
     # check how many elements are marked on each boundary
     num_marked_bdy_1 = 0
     num_marked_bdy_2 = 0
-    btag_1_bit = mesh.boundary_tag_bit("btag_test_1")
-    btag_2_bit = mesh.boundary_tag_bit("btag_test_2")
     for igrp in range(len(mesh.groups)):
         bdry_fagrps = [
             fagrp for fagrp in mesh.facial_adjacency_groups[igrp]
             if isinstance(fagrp, BoundaryAdjacencyGroup)]
         for bdry_fagrp in bdry_fagrps:
-            for flags in bdry_fagrp.flags:
-                if flags & btag_1_bit:
-                    num_marked_bdy_1 += 1
-                if flags & btag_2_bit:
-                    num_marked_bdy_2 += 1
+            if bdry_fagrp.boundary_tag == "btag_test_1":
+                num_marked_bdy_1 += len(bdry_fagrp.elements)
+            if bdry_fagrp.boundary_tag == "btag_test_2":
+                num_marked_bdy_2 += len(bdry_fagrp.elements)
 
     # raise errors if wrong number of elements marked
     if num_marked_bdy_1 != num_on_bdy:

--- a/test/test_mesh.py
+++ b/test/test_mesh.py
@@ -31,7 +31,11 @@ from arraycontext import pytest_generate_tests_for_array_contexts
 pytest_generate_tests = pytest_generate_tests_for_array_contexts(
         [PytestPyOpenCLArrayContextFactory])
 
-from meshmode.mesh import Mesh, SimplexElementGroup, TensorProductElementGroup
+from meshmode.mesh import (
+    Mesh,
+    SimplexElementGroup,
+    TensorProductElementGroup,
+    BoundaryAdjacencyGroup)
 from meshmode.discretization.poly_element import (
         default_simplex_group_factory,
         LegendreGaussLobattoTensorProductGroupFactory,
@@ -533,12 +537,12 @@ def test_boundary_tags():
     for igrp in range(len(mesh.groups)):
         bdry_fagrps = [
             fagrp for fagrp in mesh.facial_adjacency_groups[igrp]
-            if fagrp.ineighbor_group is None]
+            if isinstance(fagrp, BoundaryAdjacencyGroup)]
         for bdry_fagrp in bdry_fagrps:
-            for nbrs in bdry_fagrp.neighbors:
-                if (-nbrs) & outer_btag_bit:
+            for flags in bdry_fagrp.flags:
+                if flags & outer_btag_bit:
                     num_marked_outer_bdy += 1
-                if (-nbrs) & inner_btag_bit:
+                if flags & inner_btag_bit:
                     num_marked_inner_bdy += 1
 
     # raise errors if wrong number of elements marked
@@ -628,12 +632,12 @@ def test_box_boundary_tags(dim, nelem, mesh_type, group_cls, visualize=False):
     for igrp in range(len(mesh.groups)):
         bdry_fagrps = [
             fagrp for fagrp in mesh.facial_adjacency_groups[igrp]
-            if fagrp.ineighbor_group is None]
+            if isinstance(fagrp, BoundaryAdjacencyGroup)]
         for bdry_fagrp in bdry_fagrps:
-            for nbrs in bdry_fagrp.neighbors:
-                if (-nbrs) & btag_1_bit:
+            for flags in bdry_fagrp.flags:
+                if flags & btag_1_bit:
                     num_marked_bdy_1 += 1
-                if (-nbrs) & btag_2_bit:
+                if flags & btag_2_bit:
                     num_marked_bdy_2 += 1
 
     # raise errors if wrong number of elements marked

--- a/test/test_mesh.py
+++ b/test/test_mesh.py
@@ -530,16 +530,15 @@ def test_boundary_tags():
     outer_btag_bit = mesh.boundary_tag_bit("outer_bdy")
     inner_btag_bit = mesh.boundary_tag_bit("inner_bdy")
     for igrp in range(len(mesh.groups)):
-        bdry_fagrp = mesh.facial_adjacency_groups[igrp].get(None, None)
-
-        if bdry_fagrp is None:
-            continue
-
-        for nbrs in bdry_fagrp.neighbors:
-            if (-nbrs) & outer_btag_bit:
-                num_marked_outer_bdy += 1
-            if (-nbrs) & inner_btag_bit:
-                num_marked_inner_bdy += 1
+        bdry_fagrps = [
+            fagrp for fagrp in mesh.facial_adjacency_groups[igrp]
+            if fagrp.ineighbor_group is None]
+        for bdry_fagrp in bdry_fagrps:
+            for nbrs in bdry_fagrp.neighbors:
+                if (-nbrs) & outer_btag_bit:
+                    num_marked_outer_bdy += 1
+                if (-nbrs) & inner_btag_bit:
+                    num_marked_inner_bdy += 1
 
     # raise errors if wrong number of elements marked
     if num_marked_inner_bdy != num_on_inner_bdy:
@@ -626,16 +625,15 @@ def test_box_boundary_tags(dim, nelem, mesh_type, group_cls, visualize=False):
     btag_1_bit = mesh.boundary_tag_bit("btag_test_1")
     btag_2_bit = mesh.boundary_tag_bit("btag_test_2")
     for igrp in range(len(mesh.groups)):
-        bdry_fagrp = mesh.facial_adjacency_groups[igrp].get(None, None)
-
-        if bdry_fagrp is None:
-            continue
-
-        for nbrs in bdry_fagrp.neighbors:
-            if (-nbrs) & btag_1_bit:
-                num_marked_bdy_1 += 1
-            if (-nbrs) & btag_2_bit:
-                num_marked_bdy_2 += 1
+        bdry_fagrps = [
+            fagrp for fagrp in mesh.facial_adjacency_groups[igrp]
+            if fagrp.ineighbor_group is None]
+        for bdry_fagrp in bdry_fagrps:
+            for nbrs in bdry_fagrp.neighbors:
+                if (-nbrs) & btag_1_bit:
+                    num_marked_bdy_1 += 1
+                if (-nbrs) & btag_2_bit:
+                    num_marked_bdy_2 += 1
 
     # raise errors if wrong number of elements marked
     if num_marked_bdy_1 != num_on_bdy:


### PR DESCRIPTION
This PR:

1. Restructures `Mesh`'s facial adjacency structure to allow multiple adjacency groups for each pair of mesh element groups. In other words, `List[Dict[FacialAdjacencyGroup]]` becomes `List[List[FacialAdjacencyGroup]]`.
2. Splits `FacialAdjacencyGroup` into `InteriorAdjacencyGroup` and `BoundaryAdjacencyGroup` subclasses (with `InterPartitionAdjacencyGroup` inheriting from `BoundaryAdjacencyGroup`).
3. Splits boundary adjacency for different boundary tags into different groups.
4. Splits inter-partition adjacency for different ranks into different groups.
5. Removes `boundary_tags`/`boundary_tag_bit` from `Mesh`.
6. Adds affine transformations to `InteriorAdjacencyGroup`/`InterPartitionAdjacencyGroup`.

~~This will almost certainly need to be split into multiple PRs~~, but I wanted to throw this up here first for CI + discussion.

(Probably incomprehensible unless read commit-by-commit.)