### PR TITLE
resample_by_picking: use array expressions

### DIFF
--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -31,6 +31,7 @@ from arraycontext import PyOpenCLArrayContext as PyOpenCLArrayContextBase
 from arraycontext import PytatoPyOpenCLArrayContext as PytatoPyOpenCLArrayContextBase
 from arraycontext.pytest import (
         _PytestPyOpenCLArrayContextFactoryWithClass,
+        _PytestPytatoPyOpenCLArrayContextFactory,
         register_pytest_array_context_factory)
 
 
@@ -255,10 +256,20 @@ class PytestPyOpenCLArrayContextFactoryWithHostScalars(
     force_device_scalars = False
 
 
+class PytestPytatoPyOpenCLArrayContextFactory(
+        _PytestPytatoPyOpenCLArrayContextFactory):
+
+    @property
+    def actx_class(self):
+        return PytatoPyOpenCLArrayContext
+
+
 register_pytest_array_context_factory("meshmode.pyopencl",
         PytestPyOpenCLArrayContextFactory)
 register_pytest_array_context_factory("meshmode.pyopencl-deprecated",
         PytestPyOpenCLArrayContextFactoryWithHostScalars)
+register_pytest_array_context_factory("meshmode.pytato_cl",
+        PytestPytatoPyOpenCLArrayContextFactory)
 
 # }}}
 


### PR DESCRIPTION
Why is this approach better?
For PytatoArrayContext: cleaner to fuse over other possible approach of inferring the semantics of a loopy call.

Draft because:
- [x] Needs https://github.com/inducer/pytato/pull/136
- [x] Needs https://github.com/inducer/arraycontext/pull/74
- [x] Needs https://github.com/inducer/arraycontext/pull/125
---
- [x] Point arraycontext in `requirements.txt` back to `main`.