### PR TITLE
Only oversubscribe on openmpi

### DIFF
--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -24,6 +24,7 @@ dependencies:
 - pybind11
 
 # for MPI-based tests
+- openmpi
 - mpi4py
 
 # for xdmf/hdf5 visualizer

--- a/test/test_partition.py
+++ b/test/test_partition.py
@@ -347,7 +347,7 @@ def _test_mpi_boundary_swap(dim, order, num_groups):
     from arraycontext import PyOpenCLArrayContext
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
-    actx = PyOpenCLArrayContext(queue)
+    actx = PyOpenCLArrayContext(queue, force_device_scalars=True)
 
     from meshmode.discretization import Discretization
     vol_discr = Discretization(actx, local_mesh, group_factory)


### PR DESCRIPTION
I'm guessing `mpi4py` started pulling in `mpich` instead of `openmpi` in the CI (although couldn't find any changes in the conda-forge packages?) and `test_partition` started failing because it couldn't find the `--oversubscribe` flag.

This just adds `openmpi` to the conda env.