### PR TITLE
Introduce MeshElementGroup-generic group factories

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 SPHINXOPTS    ?= -n
-SPHINXBUILD   ?= sphinx-build
+SPHINXBUILD   ?= python $(shell which sphinx-build)
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/meshmode/discretization/__init__.py
+++ b/meshmode/discretization/__init__.py
@@ -97,13 +97,14 @@ class ElementGroupBase(metaclass=ABCMeta):
     .. autoattribute:: shape
     .. autoattribute:: space
 
+    .. automethod:: __init__
     .. automethod:: discretization_key
     """
 
     def __init__(self, mesh_el_group, order, index):
         """
         :arg mesh_el_group: an instance of
-            :class:`meshmode.mesh.MeshElementGroup`
+            :class:`~meshmode.mesh.MeshElementGroup`.
         """
         self.mesh_el_group = mesh_el_group
         self.order = order

--- a/meshmode/discretization/poly_element.py
+++ b/meshmode/discretization/poly_element.py
@@ -72,7 +72,7 @@ Group factories
 ^^^^^^^^^^^^^^^
 
 .. autoclass:: ElementGroupFactory
-.. autoclass:: HeterogeneousOrderBasedGroupFactory
+.. autoclass:: TypeMappingGroupFactory
 
 Simplicial group factories
 --------------------------
@@ -96,8 +96,8 @@ Tensor product group factories
 .. autoclass:: LegendreGaussLobattoTensorProductGroupFactory
 .. autoclass:: EquidistantTensorProductGroupFactory
 
-Heterogeneous group factories
------------------------------
+Type-based group factories
+--------------------------
 
 .. autoclass:: InterpolatoryEdgeClusteredGroupFactory
 .. autoclass:: InterpolatoryQuadratureGroupFactory
@@ -653,7 +653,7 @@ class HomogeneousOrderBasedGroupFactory(ElementGroupFactory):
         return self.group_class(mesh_el_group, self.order, index)
 
 
-class HeterogeneousOrderBasedGroupFactory(ElementGroupFactory):
+class TypeMappingGroupFactory(ElementGroupFactory):
     """
     .. automethod:: __init__
     .. automethod:: __call__
@@ -688,11 +688,11 @@ class HeterogeneousOrderBasedGroupFactory(ElementGroupFactory):
             return cls(mesh_el_group, self.order, index)
 
 
-class OrderAndTypeBasedGroupFactory(HeterogeneousOrderBasedGroupFactory):
+class OrderAndTypeBasedGroupFactory(TypeMappingGroupFactory):
     def __init__(self, order, simplex_group_class, tensor_product_group_class):
         from warnings import warn
         warn("OrderAndTypeBasedGroupFactory is deprecated and will go away in 2023. "
-                "Use HeterogeneousOrderBasedGroupFactory instead.",
+                "Use TypeMappingGroupFactory instead.",
                 DeprecationWarning, stacklevel=2)
 
         super().__init__(order, {
@@ -824,7 +824,7 @@ class _DefaultPolynomialSimplexGroupFactory(ElementGroupFactory):
         return factory(mesh_el_group, index)
 
 
-class InterpolatoryEdgeClusteredGroupFactory(HeterogeneousOrderBasedGroupFactory):
+class InterpolatoryEdgeClusteredGroupFactory(TypeMappingGroupFactory):
     def __init__(self, order):
         super().__init__(order, {
             _MeshSimplexElementGroup: _DefaultPolynomialSimplexGroupFactory(order),
@@ -833,7 +833,7 @@ class InterpolatoryEdgeClusteredGroupFactory(HeterogeneousOrderBasedGroupFactory
             })
 
 
-class InterpolatoryQuadratureGroupFactory(HeterogeneousOrderBasedGroupFactory):
+class InterpolatoryQuadratureGroupFactory(TypeMappingGroupFactory):
     def __init__(self, order):
         super().__init__(order, {
             _MeshSimplexElementGroup: InterpolatoryQuadratureSimplexElementGroup,
@@ -841,7 +841,7 @@ class InterpolatoryQuadratureGroupFactory(HeterogeneousOrderBasedGroupFactory):
             })
 
 
-class InterpolatoryEquidistantGroupFactory(HeterogeneousOrderBasedGroupFactory):
+class InterpolatoryEquidistantGroupFactory(TypeMappingGroupFactory):
     def __init__(self, order):
         super().__init__(order, {
             _MeshSimplexElementGroup: PolynomialEquidistantSimplexElementGroup,
@@ -849,7 +849,7 @@ class InterpolatoryEquidistantGroupFactory(HeterogeneousOrderBasedGroupFactory):
             })
 
 
-class QuadratureGroupFactory(HeterogeneousOrderBasedGroupFactory):
+class QuadratureGroupFactory(TypeMappingGroupFactory):
     def __init__(self, order):
         super().__init__(order, {
             _MeshSimplexElementGroup: QuadratureSimplexElementGroup,
@@ -857,7 +857,7 @@ class QuadratureGroupFactory(HeterogeneousOrderBasedGroupFactory):
             })
 
 
-class ModalGroupFactory(HeterogeneousOrderBasedGroupFactory):
+class ModalGroupFactory(TypeMappingGroupFactory):
     def __init__(self, order):
         super().__init__(order, {
             _MeshSimplexElementGroup: ModalSimplexElementGroup,

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -1070,8 +1070,6 @@ def make_visualizer(actx, discr, vis_order=None,
         equidistant nodes. If plotting high-order Lagrange VTK elements, this
         needs to be set to *True*.
     """
-    from meshmode.discretization.poly_element import OrderAndTypeBasedGroupFactory
-
     vis_discr = None
     if (element_shrink_factor is None
             and not force_equidistant
@@ -1079,21 +1077,13 @@ def make_visualizer(actx, discr, vis_order=None,
         vis_discr = discr
     else:
         if force_equidistant:
-            from meshmode.discretization.poly_element import (
-                PolynomialEquidistantSimplexElementGroup as SimplexElementGroup,
-                EquidistantTensorProductElementGroup as TensorElementGroup)
+            from meshmode.discretization.poly_element import \
+                InterpolatoryEquidistantGroupFactory as VisGroupFactory
         else:
-            from meshmode.discretization.poly_element import (
-                PolynomialWarpAndBlendElementGroup as SimplexElementGroup,
-                LegendreGaussLobattoTensorProductElementGroup as TensorElementGroup)
+            from meshmode.discretization.poly_element import \
+                InterpolatoryEdgeClusteredGroupFactory as VisGroupFactory
 
-        vis_discr = discr.copy(
-                actx=actx,
-                group_factory=OrderAndTypeBasedGroupFactory(
-                    vis_order,
-                    simplex_group_class=SimplexElementGroup,
-                    tensor_product_group_class=TensorElementGroup),
-                )
+        vis_discr = discr.copy(actx=actx, group_factory=VisGroupFactory(vis_order))
 
         if all(grp.discretization_key() == vgrp.discretization_key()
                 for grp, vgrp in zip(discr.groups, vis_discr.groups)):

--- a/meshmode/mesh/visualization.py
+++ b/meshmode/mesh/visualization.py
@@ -311,17 +311,10 @@ def vtk_visualize_mesh(actx, mesh, filename,
     if not vtk_high_order:
         vis_order = None
 
-    from meshmode.discretization.poly_element import (
-            PolynomialWarpAndBlendElementGroup,
-            LegendreGaussLobattoTensorProductElementGroup,
-            OrderAndTypeBasedGroupFactory
-            )
+    from meshmode.discretization.poly_element import \
+            InterpolatoryEdgeClusteredGroupFactory
     from meshmode.discretization import Discretization
-    discr = Discretization(actx, mesh, OrderAndTypeBasedGroupFactory(
-        order,
-        simplex_group_class=PolynomialWarpAndBlendElementGroup,
-        tensor_product_group_class=LegendreGaussLobattoTensorProductElementGroup
-        ))
+    discr = Discretization(actx, mesh, InterpolatoryEdgeClusteredGroupFactory(order))
 
     from meshmode.discretization.visualization import make_visualizer
     vis = make_visualizer(actx, discr,


### PR DESCRIPTION
Explicitly using `OrderAndTypeBasedGroupFactory` everywhere (in inducer/pytential#46) was getting a bit verbose.

This basically introduces a `HeterogeneousOrderBasedGroupFactory` (naming?) that's supposedly a bit more extensible than `OrderAndTypeBasedGroupFactory` and a bunch of subclasses for the common cases that meshmode/grudge/pytential use.

Not quite sure how future proof this is, so suggestions welcome!