### PR TITLE
Check `DOFArray` group array sizes in connections and visualization

### DIFF
--- a/meshmode/discretization/connection/direct.py
+++ b/meshmode/discretization/connection/direct.py
@@ -325,11 +325,9 @@ class DirectDiscretizationConnection(DiscretizationConnection):
         if is_array_container(ary) and not isinstance(ary, DOFArray):
             return map_array_container(self, ary)
 
-        if not isinstance(ary, DOFArray):
-            raise TypeError("non-array passed to discretization connection")
-
-        if ary.shape != (len(self.from_discr.groups),):
-            raise ValueError("invalid shape of incoming resampling data")
+        if __debug__:
+            from meshmode.dof_array import check_dofarray_against_discr
+            check_dofarray_against_discr(self.from_discr, ary)
 
         if (ary.array_context.permits_inplace_modification
                 and not _force_no_inplace_updates):

--- a/meshmode/discretization/connection/projection.py
+++ b/meshmode/discretization/connection/projection.py
@@ -123,11 +123,9 @@ class L2ProjectionInverseDiscretizationConnection(DiscretizationConnection):
         if is_array_container(ary) and not isinstance(ary, DOFArray):
             return map_array_container(self, ary)
 
-        if not isinstance(ary, DOFArray):
-            raise TypeError("non-array passed to discretization connection")
-
-        if ary.shape != (len(self.from_discr.groups),):
-            raise ValueError("invalid shape of incoming resampling data")
+        if __debug__:
+            from meshmode.dof_array import check_dofarray_against_discr
+            check_dofarray_against_discr(self.from_discr, ary)
 
         actx = ary.array_context
 

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -49,7 +49,7 @@ __doc__ = """
 def separate_by_real_and_imag(names_and_fields, real_only):
     """
     :arg names_and_fields: input data array must be already flattened into a
-        single :mod:`numpy` array using :func:`resample_to_numpy`.
+        single :mod:`numpy` array using :func:`_resample_to_numpy`.
     """
 
     for name, field in names_and_fields:
@@ -91,7 +91,7 @@ def _stack_object_array(vec, *, by_group=False):
         ])
 
 
-def resample_to_numpy(conn, vec, *, stack=False, by_group=False):
+def _resample_to_numpy(conn, vis_discr, vec, *, stack=False, by_group=False):
     """
     :arg stack: if *True* object arrays are stacked into a single
         :class:`~numpy.ndarray`.
@@ -105,7 +105,7 @@ def resample_to_numpy(conn, vec, *, stack=False, by_group=False):
     if isinstance(vec, np.ndarray) and vec.dtype.char == "O":
         from pytools.obj_array import obj_array_vectorize
         r = obj_array_vectorize(
-                lambda x: resample_to_numpy(conn, x, by_group=by_group),
+                lambda x: _resample_to_numpy(conn, vis_discr, x, by_group=by_group),
                 vec)
 
         return _stack_object_array(r, by_group=by_group) if stack else r
@@ -121,6 +121,10 @@ def resample_to_numpy(conn, vec, *, stack=False, by_group=False):
                 np.full(grp.ndofs, vec) for grp in conn.to_discr.groups
                 ])
         elif isinstance(vec, DOFArray):
+            if __debug__:
+                from meshmode.dof_array import check_dofarray_against_discr
+                check_dofarray_against_discr(vis_discr, vec)
+
             return make_obj_array([
                 actx.to_numpy(ivec).reshape(-1) for ivec in vec
                 ])
@@ -131,6 +135,10 @@ def resample_to_numpy(conn, vec, *, stack=False, by_group=False):
             nnodes = sum(grp.ndofs for grp in conn.to_discr.groups)
             return np.full(nnodes, vec)
         elif isinstance(vec, DOFArray):
+            if __debug__:
+                from meshmode.dof_array import check_dofarray_against_discr
+                check_dofarray_against_discr(vis_discr, vec)
+
             return actx.to_numpy(flatten(vec))
         else:
             raise TypeError(f"unsupported array type: {type(vec).__name__}")
@@ -528,7 +536,7 @@ class Visualizer:
         do_show = kwargs.pop("do_show", True)
 
         nodes = self._vis_nodes_numpy()
-        field = resample_to_numpy(self.connection, field)
+        field = _resample_to_numpy(self.connection, self.vis_discr, field)
 
         assert nodes.shape[0] == self.vis_discr.ambient_dim
         vis_connectivity = self._vtk_connectivity.groups[0].vis_connectivity
@@ -707,7 +715,8 @@ class Visualizer:
 
         names_and_fields = preprocess_fields(names_and_fields)
         names_and_fields = [
-                (name, resample_to_numpy(self.connection, fld))
+                (name, _resample_to_numpy(
+                    self.connection, self.vis_discr, fld))
                 for name, fld in names_and_fields
                 ]
 
@@ -822,8 +831,8 @@ class Visualizer:
     @memoize_method
     def _xdmf_nodes_numpy(self):
         actx = self.vis_discr._setup_actx
-        return resample_to_numpy(
-                lambda x: x,
+        return _resample_to_numpy(
+                lambda x: x, self.vis_discr,
                 thaw(self.vis_discr.nodes(), actx),
                 stack=True, by_group=True)
 
@@ -886,8 +895,8 @@ class Visualizer:
 
         names_and_fields = preprocess_fields(names_and_fields)
         names_and_fields = [
-                (name, resample_to_numpy(
-                    self.connection, field,
+                (name, _resample_to_numpy(
+                    self.connection, self.vis_discr, field,
                     stack=True, by_group=True))
                 for name, field in names_and_fields
                 ]
@@ -1006,7 +1015,7 @@ class Visualizer:
         norm = kwargs.pop("norm", None)
 
         nodes = self._vis_nodes_numpy()
-        field = resample_to_numpy(self.connection, field)
+        field = _resample_to_numpy(self.connection, self.vis_discr, field)
 
         assert nodes.shape[0] == self.vis_discr.ambient_dim
 
@@ -1060,6 +1069,10 @@ class Visualizer:
 
     # }}}
 
+# }}}
+
+
+# {{{ make_visualizer
 
 def make_visualizer(actx, discr, vis_order=None,
         element_shrink_factor=None, force_equidistant=False):

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -59,6 +59,9 @@ __doc__ = """
 .. autofunction:: flat_norm
 
 .. autofunction:: array_context_for_pickling
+
+.. autoexception:: InconsistentDOFArray
+.. autofunction:: check_dofarray_against_discr
 """
 
 
@@ -728,6 +731,39 @@ def array_context_for_pickling(actx: ArrayContext):
 # }}}
 
 
+# {{{ checking
+
+class InconsistentDOFArray(ValueError):
+    pass
+
+
+def check_dofarray_against_discr(discr, dof_ary: DOFArray):
+    """Verify that the :class:`DOFArray` *dof_ary* is consistent with
+    the discretization *discr*, in terms of things like group count,
+    number of elements, and number of DOFs per element. If a discrepancy is
+    detected, :exc:`InconsistentDOFArray` is raised.
+
+    :arg discr: a :class:`~meshmode.discretization.Discretization`
+        against which *dof_ary* is to be checked.
+    """
+    if not isinstance(dof_ary, DOFArray):
+        raise TypeError("non-array passed to check_dofarray_against_discr")
+
+    if len(dof_ary) != len(discr.groups):
+        raise InconsistentDOFArray(
+                "DOFArray has unexpected number of groups "
+                f"({len(dof_ary)}, expected: {len(discr.groups)})")
+
+    for i, (grp, grp_ary) in enumerate(zip(discr.groups, dof_ary)):
+        expected_shape = (grp.nelements, grp.nunit_dofs)
+        if grp_ary.shape != expected_shape:
+            raise InconsistentDOFArray(
+                    f"DOFArray group {i} array has unexpected shape. "
+                    f"(observed: {grp_ary.shape}, expected: {expected_shape})")
+
+# }}}
+
+
 # {{{ deprecated
 
 obj_or_dof_array_vectorize = MovedFunctionDeprecationWrapper(
@@ -754,5 +790,6 @@ def thaw(actx, ary):
 freeze = MovedFunctionDeprecationWrapper(_freeze, deadline="2022")
 
 # }}}
+
 
 # vim: foldmethod=marker

--- a/meshmode/interop/firedrake/connection.py
+++ b/meshmode/interop/firedrake/connection.py
@@ -545,6 +545,10 @@ class FiredrakeConnection:
             out_data = out_data.reshape(shape)
 
         def resample_and_reorder(fd_data, dof_array):
+            if __debug__:
+                from meshmode.dof_array import check_dofarray_against_discr
+                check_dofarray_against_discr(self.discr, dof_array)
+
             # pull data into numpy
             dof_np = dof_array.array_context.to_numpy(dof_array[self.group_nr])
             # resample the data and store in firedrake ordering


### PR DESCRIPTION
I observed that it's currently possible to feed a `DOFArray` for a non-matching discretization to a visualizer or a connection. This adds some checks to catch that. That isn't free, but IMO it's well worth the cost. I'm honestly almost expecting to see some failures in CI, which would immediately prove the worth of these changes.