### PR TITLE
Use force_dim_axis in InterpolatoryQuadratureSimplexElementGroup

### DIFF
--- a/meshmode/discretization/poly_element.py
+++ b/meshmode/discretization/poly_element.py
@@ -254,7 +254,7 @@ class InterpolatoryQuadratureSimplexElementGroup(PolynomialSimplexElementGroupBa
         if dims == 0:
             return mp.ZeroDimensionalQuadrature()
         elif dims == 1:
-            return mp.LegendreGaussQuadrature(self.order)
+            return mp.LegendreGaussQuadrature(self.order, force_dim_axis=True)
         else:
             return mp.VioreanuRokhlinSimplexQuadrature(self.order, dims)
 


### PR DESCRIPTION
Gets rid of a [deprecation warning](https://github.com/inducer/modepy/blob/511f99325d4cf2e1b190b3248db526427f2d3442/modepy/quadrature/jacobi_gauss.py#L56-L61).

This would need to also be set in the tensor product element groups, but that needs a bit of work in `modepy` to extend `tensor_product_nodes`, which is part of inducer/modepy#41.