### PR TITLE
Disallow complex fields in matplotlib visualizer

### DIFF
--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -1016,6 +1016,10 @@ class Visualizer:
 
         nodes = self._vis_nodes_numpy()
         field = _resample_to_numpy(self.connection, self.vis_discr, field)
+        if not np.can_cast(field.dtype, float, "same_kind"):
+            raise ValueError(
+                    f"fields of dtype {field.dtype} are not supported: "
+                    "cannot be converted to float")
 
         assert nodes.shape[0] == self.vis_discr.ambient_dim
 

--- a/test/test_visualization.py
+++ b/test/test_visualization.py
@@ -184,7 +184,8 @@ def test_visualizers(actx_factory, dim, group_cls):
 
     if mesh.dim == 2 and is_simplex:
         try:
-            vis.show_scalar_in_matplotlib_3d(f, do_show=False)
+            # NOTE: matplotlib only supports real fields
+            vis.show_scalar_in_matplotlib_3d(actx.np.real(f), do_show=False)
         except ImportError:
             logger.info("matplotlib not available")
 


### PR DESCRIPTION
Not quite sure what it was doing before (just taking the real part somewhere?), but in matplotlib 3.5 they added an extra check that raises on complex inputs.