### PR TITLE
Disable actx.clone on discr.copy

### DIFF
--- a/meshmode/discretization/__init__.py
+++ b/meshmode/discretization/__init__.py
@@ -427,6 +427,16 @@ class Discretization:
                 }[self.real_dtype.type])
 
         if _force_actx_clone:
+            # We're cloning the array context here to make the setup actx
+            # distinct from the "ambient" actx. This allows us to catch
+            # errors where arrays from both are inadvertently mixed.
+            # See https://github.com/inducer/arraycontext/pull/22/files
+            # for context.
+            # _force_actx clone exists to disable cloning of the array
+            # context when copying a discretization, to allow
+            # preserving caches.
+            # See https://github.com/inducer/meshmode/pull/293
+            # for context.
             actx = actx.clone()
 
         self._setup_actx = actx

--- a/meshmode/discretization/__init__.py
+++ b/meshmode/discretization/__init__.py
@@ -395,8 +395,10 @@ class Discretization:
     .. automethod:: quad_weights
     """
 
-    def __init__(self, actx: ArrayContext, mesh, group_factory,
-            real_dtype=np.float64):
+    def __init__(self,
+            actx: ArrayContext, mesh, group_factory,
+            real_dtype=np.float64,
+            _force_actx_clone=True):
         """
         :arg actx: A :class:`ArrayContext` used to perform computation needed
             during initial set-up of the mesh.
@@ -424,7 +426,10 @@ class Discretization:
                 np.float64: np.complex128
                 }[self.real_dtype.type])
 
-        self._setup_actx = actx.clone()
+        if _force_actx_clone:
+            actx = actx.clone()
+
+        self._setup_actx = actx
         self._group_factory = group_factory
         self._cached_nodes = None
 
@@ -435,10 +440,11 @@ class Discretization:
         """
 
         return type(self)(
-                self._setup_actx if actx is None else actx,
+                self._setup_actx if actx is None else actx.clone(),
                 self.mesh if mesh is None else mesh,
                 self._group_factory if group_factory is None else group_factory,
                 self.real_dtype if real_dtype is None else real_dtype,
+                _force_actx_clone=False,
                 )
 
     @property


### PR DESCRIPTION
Was timing the pytential FMM on moving geometries and noticed that a lot of its caches (like [this one](https://github.com/inducer/pytential/blob/87ba4e4be2ab63503f3c4e554e8c9667a1f25f67/pytential/qbx/__init__.py#L340-L346)) kept going away because the `_setup_actx` kept getting cloned.

This updates `Discretization.copy` to only make a clone if it's given a new `actx`, but keep the existing `_setup_actx` as is otherwise.

EDIT: this seems to save about 10%-15% of the time in my small `pytential` benchmark.