### PR TITLE
Add support for VTKHDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ a.out
 *.pvtu
 *.h5
 *.xmf
+*.hdf
 
 .cache
 .pytest_cache

--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -28,7 +28,7 @@ dependencies:
 - mpi4py
 
 # for xdmf/hdf5 visualizer
-- h5py
+- h5py=*=mpi_openmpi*
 
 # Only needed to make pylint succeed
 - matplotlib-base

--- a/examples/parallel-vtkhdf.py
+++ b/examples/parallel-vtkhdf.py
@@ -1,0 +1,88 @@
+import logging
+import numpy as np
+from meshmode.mesh import Mesh
+
+logger = logging.getLogger(__file__)
+
+
+def make_example_mesh(ambient_dim: int, nelements: int, order: int) -> Mesh:
+    import meshmode.mesh.generation as mgen
+    if ambient_dim == 2:
+        return mgen.make_curve_mesh(
+            mgen.starfish,
+            np.linspace(0.0, 1.0, nelements + 1),
+            order=order)
+    else:
+        return mgen.generate_torus(4.0, 2.0,
+            n_major=nelements, n_minor=nelements // 2,
+            order=order)
+
+
+def main(*, ambient_dim: int) -> None:
+    logging.basicConfig(level=logging.INFO)
+
+    import h5py
+    if "mpio" not in h5py.registered_drivers():
+        logger.info("h5py does not have the 'mpio' driver")
+        return
+
+    from meshmode import _acf
+    actx = _acf()
+
+    from mpi4py import MPI
+    comm = MPI.COMM_WORLD
+    mpisize = comm.Get_size()
+    mpirank = comm.Get_rank()
+
+    from meshmode.distributed import MPIMeshDistributor
+    dist = MPIMeshDistributor(comm)
+
+    order = 5
+    nelements = 64 if ambient_dim == 3 else 256
+
+    logger.info("[%4d] distributing mesh: started", mpirank)
+
+    if dist.is_mananger_rank():
+        mesh = make_example_mesh(ambient_dim, nelements, order=order)
+        logger.info("[%4d] mesh: nelements %d nvertices %d",
+                    mpirank, mesh.nelements, mesh.nvertices)
+
+        rng = np.random.default_rng()
+        part_per_element = rng.integers(mpisize, size=mesh.nelements)
+
+        local_mesh = dist.send_mesh_parts(mesh, part_per_element, mpisize)
+    else:
+        local_mesh = dist.receive_mesh_part()
+
+    logger.info("[%4d] distributing mesh: finished", mpirank)
+
+    from meshmode.discretization import Discretization
+    from meshmode.discretization.poly_element import default_simplex_group_factory
+    discr = Discretization(actx, local_mesh,
+        default_simplex_group_factory(local_mesh.dim, order=order))
+
+    logger.info("[%4d] discretization: finished", mpirank)
+
+    from arraycontext import thaw
+    vector_field = thaw(discr.nodes(), actx)
+    scalar_field = actx.np.sin(thaw(discr.nodes()[0], actx))
+    part_id = 1 + mpirank + discr.zeros(actx)
+    logger.info("[%4d] fields: finished", mpirank)
+
+    from meshmode.discretization.visualization import make_visualizer
+    vis = make_visualizer(actx, discr, vis_order=order, force_equidistant=False)
+    logger.info("[%4d] make_visualizer: finished", mpirank)
+
+    filename = f"parallel-vtkhdf-example-{ambient_dim}d.hdf"
+    vis.write_vtkhdf_file(filename, [
+        ("scalar", scalar_field),
+        ("vector", vector_field),
+        ("part_id", part_id)
+        ], comm=comm, overwrite=True, use_high_order=False)
+
+    logger.info("[%4d] write: finished: %s", mpirank, filename)
+
+
+if __name__ == "__main__":
+    main(ambient_dim=2)
+    main(ambient_dim=3)

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -481,6 +481,7 @@ class Visualizer:
     .. automethod:: show_scalar_in_matplotlib_3d
     .. automethod:: write_vtk_file
     .. automethod:: write_parallel_vtk_file
+    .. automethod:: write_vtkhdf_file
     .. automethod:: write_xdmf_file
 
     .. automethod:: copy_with_same_connectivity
@@ -847,7 +848,22 @@ class Visualizer:
             real_only: bool = False,
             overwrite: bool = False,
             h5_file_options: Optional[Dict[str, Any]] = None,
-            dset_options: Optional[Dict[str, Any]] = None):
+            dset_options: Optional[Dict[str, Any]] = None) -> None:
+        """Write a VTK HDF5 file (typical extension ``'.hdf'``) containing
+        the visualization fields in *names_and_fields*.
+
+        This function requires ``h5py`` and has support for parallel writes
+        through ``mpi4py``.
+
+        :arg comm: an ``mpi4py.Comm``-like interface that supports
+            ``Get_rank``, ``Get_size``, ``scan`` and ``reduce``. The last two
+            are required to gather global information about the points and
+            cells in the discretizations.
+        :arg h5_file_options: a :class:`dict` passed directly to
+            :class:`h5py.File` that allows controlling chunking, compatibility, etc.
+        :arg dataset_options: a :class:`dict` passed directly to
+            :meth:`h5py.Group.create_dataset`.
+        """
         # {{{ setup
 
         try:

--- a/test/test_visualization.py
+++ b/test/test_visualization.py
@@ -258,15 +258,15 @@ def test_copy_visualizer(actx_factory, ambient_dim, visualize=True):
 
     from meshmode.discretization.visualization import make_visualizer
     vis = make_visualizer(actx, discr, target_order, force_equidistant=True)
-    assert vis._vtk_connectivity
+    assert vis._vtk_linear_connectivity
     assert vis._vtk_lagrange_connectivity
 
     translated_vis = vis.copy_with_same_connectivity(actx, translated_discr)
-    assert translated_vis._cached_vtk_connectivity is not None
+    assert translated_vis._cached_vtk_linear_connectivity is not None
     assert translated_vis._cached_vtk_lagrange_connectivity is not None
 
-    assert translated_vis._vtk_connectivity \
-            is vis._vtk_connectivity
+    assert translated_vis._vtk_linear_connectivity \
+            is vis._vtk_linear_connectivity
     assert translated_vis._vtk_lagrange_connectivity \
             is vis._vtk_lagrange_connectivity
 

--- a/test/test_visualization.py
+++ b/test/test_visualization.py
@@ -168,6 +168,8 @@ def test_visualizers(actx_factory, dim, group_cls):
     from meshmode.discretization.visualization import make_visualizer
     vis = make_visualizer(actx, discr, target_order)
 
+    # {{{ vtk
+
     eltype = "simplex" if is_simplex else "box"
     basename = f"visualizer_vtk_{eltype}_{dim}d"
     vis.write_vtk_file(f"{basename}_linear.vtu", names_and_fields, overwrite=True)
@@ -176,11 +178,26 @@ def test_visualizers(actx_factory, dim, group_cls):
         vis.write_vtk_file(f"{basename}_lagrange.vtu",
                 names_and_fields, overwrite=True, use_high_order=True)
 
+    # }}}
+
+    # {{{ vtkhdf
+
+    basename = f"visualizer_vtkhdf_{eltype}_{dim}d"
+    vis.write_vtkhdf_file(f"{basename}_linear.hdf", names_and_fields, overwrite=True)
+
+    # }}}
+
+    # {{{ xdmf
+
     try:
         basename = f"visualizer_xdmf_{eltype}_{dim}d"
         vis.write_xdmf_file(f"{basename}.xmf", names_and_fields, overwrite=True)
     except ImportError:
         logger.info("h5py not available")
+
+    # }}}
+
+    # {{{ matplotlib
 
     if mesh.dim == 2 and is_simplex:
         try:
@@ -188,6 +205,9 @@ def test_visualizers(actx_factory, dim, group_cls):
             vis.show_scalar_in_matplotlib_3d(actx.np.real(f), do_show=False)
         except ImportError:
             logger.info("matplotlib not available")
+    # }}}
+
+    # {{{ mayavi
 
     if mesh.dim <= 2 and is_simplex:
         try:
@@ -195,12 +215,18 @@ def test_visualizers(actx_factory, dim, group_cls):
         except ImportError:
             logger.info("mayavi not available")
 
+    # }}}
+
+    # {{{ vtkLagrange
+
     vis = make_visualizer(actx, discr, target_order,
             force_equidistant=True)
 
     basename = f"visualizer_vtk_{eltype}_{dim}d"
     vis.write_vtk_file(f"{basename}_lagrange.vtu",
             names_and_fields, overwrite=True, use_high_order=True)
+
+    # }}}
 
 
 @pytest.mark.parametrize("ambient_dim", [2, 3])


### PR DESCRIPTION
Found out that VTK has support for HDF5 too (not sure since when?)
https://vtk.org/doc/nightly/html/VTKHDFFileFormat.html
and implemented a little writer for it. It should be better than the XDMF writer in the long run, since that seems generally unmaintained.

It has similar benefits with smaller file sizes. From the test in `test_visualization`
```
2.0M visualizer_vtk_simplex_3d_linear.vtu
1.5M visualizer_vtkhdf_simplex_3d_linear.hdf
```

Big plus is that it supports MPI too so there's no need for that `pvtu` stuff with a gazillion files!

EDIT: Tested with Paraview 5.10 and no guarantees for other version.