### PR TITLE
Pad arrays to 3d in write_vtkhdf_file

### DIFF
--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -913,6 +913,13 @@ class Visualizer:
         # https://vtk.org/doc/nightly/html/VTKHDFFileFormat.html
 
         def create_dataset(grp, name, data, *, shape, offset):
+            if data.ndim == 2 and data.shape[1] < 3:
+                # NOTE: Paraview 5.10 (with bundled VTK 9.0.20210922) seems to
+                # be hardcoded to 3D somewhere for the VTKHDF format, so we
+                # pad the point arrays as well.
+                data = np.pad(data, ((0, 0), (0, 3 - shape[1])))
+                shape = (shape[0], 3)
+
             dset = grp.create_dataset(name, shape, dtype=data.dtype, **dset_options)
             dset[offset:offset + data.shape[0]] = data
 


### PR DESCRIPTION
Just realized I didn't really check the 2D case.. and indeed it wasn't working. 

Paraview just crashed in some `vtkPoints` class saying it didn't have enough dimensions. This seems to fix it, but it's not great to store a bunch of zeros. Not sure if there's some better way..