### PR TITLE
Remove uses of MeshElementGroup.element_nr_base

### DIFF
--- a/meshmode/discretization/connection/opposite_face.py
+++ b/meshmode/discretization/connection/opposite_face.py
@@ -546,7 +546,8 @@ def make_partition_connection(actx, *, local_bdry_conn, i_local_part,
     from meshmode.discretization.connection import (
             DirectDiscretizationConnection, DiscretizationConnectionElementGroup)
 
-    local_vol_groups = local_bdry_conn.from_discr.mesh.groups
+    local_vol_mesh = local_bdry_conn.from_discr.mesh
+    local_vol_groups = local_vol_mesh.groups
 
     part_batches = [[] for _ in local_vol_groups]
 
@@ -592,7 +593,7 @@ def make_partition_connection(actx, *, local_bdry_conn, i_local_part,
 
                 local_grp_vol_elems = (
                         rem_ipag.neighbors[local_indices]
-                        - local_vol_groups[i_local_grp].element_nr_base)
+                        - local_vol_mesh.base_element_nrs[i_local_grp])
                 # These are group-local.
                 remote_grp_vol_elems = rem_ipag.elements[local_indices]
 

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -1148,8 +1148,9 @@ class Visualizer:
                 h5grp = h5grid.create_group(grp_name)
 
                 # offset connectivity back to local numbering
-                visconn = vgrp.vis_connectivity.reshape(vgrp.nsubelements, -1) \
-                        - node_nr_base
+                visconn = (
+                    vgrp.vis_connectivity.reshape(vgrp.nsubelements, -1)
+                    - node_nr_base)
                 node_nr_base += self.vis_discr.groups[igrp].ndofs
 
                 # hdf5 side
@@ -1352,9 +1353,8 @@ def write_nodal_adjacency_vtk_file(file_name, mesh,
             (mesh.ambient_dim, mesh.nelements),
             dtype=mesh.vertices.dtype)
 
-    for grp in mesh.groups:
-        iel_base = grp.element_nr_base
-        centroids[:, iel_base:iel_base+grp.nelements] = (
+    for base_element_nr, grp in zip(mesh.base_element_nrs, mesh.groups):
+        centroids[:, base_element_nr:base_element_nr + grp.nelements] = (
                 np.sum(mesh.vertices[:, grp.vertex_indices], axis=-1)
                 / grp.vertex_indices.shape[-1])
 

--- a/meshmode/distributed.py
+++ b/meshmode/distributed.py
@@ -292,10 +292,9 @@ def get_partition_by_pymetis(mesh, num_parts, *, connectivity="facial", **kwargs
         # shape: (2, n_el_pairs)
         neighbor_el_pairs = np.hstack([
                 np.array([
-                    fagrp.elements
-                    + mesh.groups[fagrp.igroup].element_nr_base,
-                    fagrp.neighbors
-                    + mesh.groups[fagrp.ineighbor_group].element_nr_base])
+                    fagrp.elements + mesh.base_element_nrs[fagrp.igroup],
+                    fagrp.neighbors + mesh.base_element_nrs[fagrp.ineighbor_group]
+                    ])
                 for fagrp_list in mesh.facial_adjacency_groups
                 for fagrp in fagrp_list
                 if isinstance(fagrp, InteriorAdjacencyGroup)

--- a/meshmode/mesh/generation.py
+++ b/meshmode/mesh/generation.py
@@ -1458,7 +1458,8 @@ def warp_and_refine_until_resolved(
                 raise FloatingPointError("Warped mesh contains non-finite nodes "
                                          "(NaN or Inf)")
 
-        for egrp in warped_mesh.groups:
+        for base_element_nr, egrp in zip(
+                warped_mesh.base_element_nrs, warped_mesh.groups):
             dim, _ = egrp.unit_nodes.shape
 
             interp_err_est_mat = simplex_interp_error_coefficient_estimator_matrix(
@@ -1478,10 +1479,8 @@ def warp_and_refine_until_resolved(
             # max over dimensions
             est_rel_interp_error = np.max(interp_error_norm_2/mapping_norm_2, axis=0)
 
-            refine_flags[
-                    egrp.element_nr_base:
-                    egrp.element_nr_base+egrp.nelements] = \
-                            est_rel_interp_error > est_rel_interp_tolerance
+            refine_flags[base_element_nr:base_element_nr + egrp.nelements] = (
+                est_rel_interp_error > est_rel_interp_tolerance)
 
         nrefined_elements = np.sum(refine_flags.astype(np.int32))
         if nrefined_elements == 0:

--- a/meshmode/mesh/refinement/no_adjacency.py
+++ b/meshmode/mesh/refinement/no_adjacency.py
@@ -89,21 +89,18 @@ class RefinerWithoutAdjacency:
                 get_group_midpoints,
                 get_group_tessellated_nodes)
 
-        for group in mesh.groups:
-            el_tess_info = get_group_tessellation_info(group)
+        for base_element_nr, grp in zip(mesh.base_element_nrs, mesh.groups):
+            el_tess_info = get_group_tessellation_info(grp)
 
             # {{{ compute counts and index arrays
 
-            grp_flags = refine_flags[
-                    group.element_nr_base:
-                    group.element_nr_base+group.nelements]
+            grp_flags = refine_flags[base_element_nr:base_element_nr + grp.nelements]
 
             nchildren = len(el_tess_info.children)
-            nchild_elements = np.ones(group.nelements, dtype=mesh.element_id_dtype)
+            nchild_elements = np.ones(grp.nelements, dtype=mesh.element_id_dtype)
             nchild_elements[grp_flags] = nchildren
 
-            child_el_indices = np.empty(
-                    group.nelements+1, dtype=mesh.element_id_dtype)
+            child_el_indices = np.empty(grp.nelements+1, dtype=mesh.element_id_dtype)
             child_el_indices[0] = 0
             child_el_indices[1:] = np.cumsum(nchild_elements)
 
@@ -122,22 +119,22 @@ class RefinerWithoutAdjacency:
                             list(range(
                                 child_el_indices[iel],
                                 child_el_indices[iel]+nchild_elements[iel]))
-                            for iel in range(group.nelements)]))
+                            for iel in range(grp.nelements)]))
 
             # {{{ get new vertices together
 
             if perform_vertex_updates:
                 midpoints = get_group_midpoints(
-                        group, el_tess_info, refining_el_old_indices)
+                        grp, el_tess_info, refining_el_old_indices)
 
                 new_vertex_indices = np.empty(
-                    (new_nelements, group.vertex_indices.shape[1]),
+                    (new_nelements, grp.vertex_indices.shape[1]),
                     dtype=mesh.vertex_id_dtype)
                 new_vertex_indices.fill(-17)
 
                 # copy over unchanged vertices
                 new_vertex_indices[unrefined_el_new_indices] = \
-                        group.vertex_indices[~grp_flags]
+                        grp.vertex_indices[~grp_flags]
 
                 for old_iel in refining_el_old_indices:
                     new_iel_base = child_el_indices[old_iel]
@@ -148,14 +145,14 @@ class RefinerWithoutAdjacency:
 
                     # carry over old vertices
                     refining_vertices[el_tess_info.orig_vertex_indices] = \
-                            group.vertex_indices[old_iel]
+                            grp.vertex_indices[old_iel]
 
                     for imidpoint, (iref_midpoint, (v1, v2)) in enumerate(zip(
                             el_tess_info.midpoint_indices,
                             el_tess_info.midpoint_vertex_pairs)):
 
-                        global_v1 = group.vertex_indices[old_iel, v1]
-                        global_v2 = group.vertex_indices[old_iel, v2]
+                        global_v1 = grp.vertex_indices[old_iel, v1]
+                        global_v2 = grp.vertex_indices[old_iel, v2]
 
                         if global_v1 > global_v2:
                             global_v1, global_v2 = global_v2, global_v1
@@ -187,16 +184,16 @@ class RefinerWithoutAdjacency:
             # {{{ get new nodes together
 
             new_nodes = np.empty(
-                (mesh.ambient_dim, new_nelements, group.nunit_nodes),
-                dtype=group.nodes.dtype)
+                (mesh.ambient_dim, new_nelements, grp.nunit_nodes),
+                dtype=grp.nodes.dtype)
 
             new_nodes.fill(float("nan"))
 
             # copy over unchanged nodes
-            new_nodes[:, unrefined_el_new_indices] = group.nodes[:, ~grp_flags]
+            new_nodes[:, unrefined_el_new_indices] = grp.nodes[:, ~grp_flags]
 
             tessellated_nodes = get_group_tessellated_nodes(
-                    group, el_tess_info, refining_el_old_indices)
+                    grp, el_tess_info, refining_el_old_indices)
 
             for old_iel in refining_el_old_indices:
                 new_iel_base = child_el_indices[old_iel]
@@ -208,11 +205,11 @@ class RefinerWithoutAdjacency:
             # }}}
 
             new_el_groups.append(
-                group.make_group(
-                    order=group.order,
+                grp.make_group(
+                    order=grp.order,
                     vertex_indices=new_vertex_indices,
                     nodes=new_nodes,
-                    unit_nodes=group.unit_nodes))
+                    unit_nodes=grp.unit_nodes))
 
         if perform_vertex_updates:
             new_vertices = np.empty(

--- a/meshmode/mesh/refinement/utils.py
+++ b/meshmode/mesh/refinement/utils.py
@@ -97,7 +97,7 @@ def is_symmetric(relation, debug=False):
 
 def check_nodal_adj_against_geometry(mesh, tol=1e-12):
     def group_and_iel_to_global_iel(igrp, iel):
-        return mesh.groups[igrp].element_nr_base + iel
+        return mesh.base_element_nrs[igrp] + iel
 
     logger.debug("nodal adj test: tree build")
     from meshmode.mesh.tools import make_element_lookup_tree

--- a/meshmode/mesh/visualization.py
+++ b/meshmode/mesh/visualization.py
@@ -189,7 +189,7 @@ def write_vertex_vtk_file(mesh, file_name,
 
     cell_types = np.empty(mesh.nelements, dtype=np.uint8)
     cell_types.fill(255)
-    for egrp in mesh.groups:
+    for base_element_nr, egrp in zip(mesh.base_element_nrs, mesh.groups):
         if isinstance(egrp, SimplexElementGroup):
             vtk_cell_type = {
                     1: VTK_LINE,
@@ -206,10 +206,7 @@ def write_vertex_vtk_file(mesh, file_name,
             raise NotImplementedError("mesh vtk file writing for "
                     "element group of type '%s'" % type(egrp).__name__)
 
-        cell_types[
-                egrp.element_nr_base:
-                egrp.element_nr_base + egrp.nelements] = \
-                        vtk_cell_type
+        cell_types[base_element_nr:base_element_nr + egrp.nelements] = vtk_cell_type
 
     assert (cell_types != 255).all()
 
@@ -275,9 +272,9 @@ def mesh_to_tikz(mesh):
     drawel_lines = []
     drawel_lines.append(r"\def\drawelements#1{")
 
-    for grp in mesh.groups:
+    for base_element_nr, grp in zip(mesh.base_element_nrs, mesh.groups):
         for iel, el in enumerate(grp.vertex_indices):
-            el_nr = grp.element_nr_base+iel+1
+            el_nr = base_element_nr + iel + 1
             elverts = mesh.vertices[:, el]
 
             centroid = np.average(elverts, axis=1)

--- a/test/test_partition.py
+++ b/test/test_partition.py
@@ -185,11 +185,11 @@ def _check_for_cross_rank_adj(mesh, part_per_element):
             if isinstance(grp, InteriorAdjacencyGroup)]
         for fagrp in int_grps:
             ineighbor_grp = fagrp.ineighbor_group
-            neighbor_grp = mesh.groups[ineighbor_grp]
             for iface in range(len(fagrp.elements)):
-                part = part_per_element[fagrp.elements[iface] + grp.element_nr_base]
+                part = part_per_element[
+                    fagrp.elements[iface] + mesh.base_element_nrs[igrp]]
                 neighbor_part = part_per_element[
-                    fagrp.neighbors[iface] + neighbor_grp.element_nr_base]
+                    fagrp.neighbors[iface] + mesh.base_element_nrs[ineighbor_grp]]
                 if part != neighbor_part:
                     return True
     return False
@@ -277,7 +277,7 @@ def test_partition_mesh(mesh_size, num_parts, num_groups, dim, scramble_partitio
             for ipagrp in ipagrps:
                 n_part_num = ipagrp.ineighbor_partition
                 num_tags[n_part_num] += len(ipagrp.elements)
-                elem_base = part.groups[grp_num].element_nr_base
+                elem_base = part.base_element_nrs[grp_num]
                 for idx in range(len(ipagrp.elements)):
                     elem = ipagrp.elements[idx]
                     meshwide_elem = elem_base + elem
@@ -296,7 +296,7 @@ def test_partition_mesh(mesh_size, num_parts, num_groups, dim, scramble_partitio
                         and fagrp.ineighbor_partition == part_num]
                     found_reverse_adj = False
                     for n_ipagrp in n_ipagrps:
-                        n_elem_base = n_part.groups[n_grp_num].element_nr_base
+                        n_elem_base = n_part.base_element_nrs[n_grp_num]
                         n_elem = n_meshwide_elem - n_elem_base
                         n_idx = index_lookup_table[
                             n_part_num, n_grp_num, n_elem, n_face]
@@ -313,8 +313,8 @@ def test_partition_mesh(mesh_size, num_parts, num_groups, dim, scramble_partitio
                     p_grp_num = find_group_indices(mesh.groups, p_meshwide_elem)
                     p_n_grp_num = find_group_indices(mesh.groups, p_meshwide_n_elem)
 
-                    p_elem_base = mesh.groups[p_grp_num].element_nr_base
-                    p_n_elem_base = mesh.groups[p_n_grp_num].element_nr_base
+                    p_elem_base = mesh.base_element_nrs[p_grp_num]
+                    p_n_elem_base = mesh.base_element_nrs[p_n_grp_num]
                     p_elem = p_meshwide_elem - p_elem_base
                     p_n_elem = p_meshwide_n_elem - p_n_elem_base
 


### PR DESCRIPTION
* Adds a `Mesh.element_nr_base` and `Mesh.node_nr_base`, which are arrays of size `len(groups)`.
* Uses those everywhere instead of `MeshElementGroup.element_nr_base` and `node_nr_base`, except in `refinement.Refiner` since that's supposed to go away anyway.

`element_nr_base` and `node_nr_base` are still set in `Mesh.__init__` in case anyone uses them, so not quite sure how to deprecate them.

Work towards #224.