### PR TITLE
Deprecate ElementGroupBase.index

### DIFF
--- a/meshmode/discretization/__init__.py
+++ b/meshmode/discretization/__init__.py
@@ -204,7 +204,9 @@ class ElementGroupFactory(Protocol):
     def __call__(self,
             mesh_el_group: _MeshElementGroup,
             index: Optional[int] = None) -> ElementGroupBase:
-        """Create a new :class:`ElementGroupBase` for the given *mesh_el_group*."""
+        """Create a new :class:`~meshmode.discretization.ElementGroupBase`
+        for the given *mesh_el_group*.
+        """
 
 # }}}
 
@@ -441,8 +443,7 @@ class Discretization:
             computation needed during initial set-up of the discretization.
         :arg mesh: a :class:`~meshmode.mesh.Mesh` over which the discretization
             is built.
-        :arg group_factory: an
-            :class:`~meshmode.discretization.poly_element.ElementGroupFactory`.
+        :arg group_factory: an :class:`~meshmode.discretization.ElementGroupFactory`.
         :arg real_dtype: The :mod:`numpy` data type used for representing real
             data, either ``numpy.float32`` or ``numpy.float64``.
         """

--- a/meshmode/discretization/__init__.py
+++ b/meshmode/discretization/__init__.py
@@ -23,7 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from abc import ABCMeta, abstractproperty, abstractmethod
+from abc import ABC, abstractmethod
 from warnings import warn
 from typing import Hashable, Iterable, Optional
 try:
@@ -91,7 +91,7 @@ class NoninterpolatoryElementGroupError(ElementGroupTypeError):
 
 # {{{ element group base
 
-class ElementGroupBase(metaclass=ABCMeta):
+class ElementGroupBase(ABC):
     """Defines a discrete function space on a homogeneous
     (in terms of element type and order) subset of a :class:`Discretization`.
     These correspond one-to-one with :class:`meshmode.mesh.MeshElementGroup`.
@@ -143,7 +143,8 @@ class ElementGroupBase(metaclass=ABCMeta):
         """
         return self.mesh_el_group.nelements
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def nunit_dofs(self):
         """The number of degrees of freedom ("DOFs")
         associated with a single element.
@@ -163,13 +164,15 @@ class ElementGroupBase(metaclass=ABCMeta):
         """
         return self.mesh_el_group.dim
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def shape(self):
         """Returns a subclass of :class:`modepy.Shape` representing
         the reference element defining the element group.
         """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def space(self):
         """Returns a :class:`modepy.FunctionSpace` representing
         the underlying polynomial space defined on the element

--- a/meshmode/discretization/connection/modal.py
+++ b/meshmode/discretization/connection/modal.py
@@ -146,7 +146,7 @@ class NodalToModalDiscretizationConnection(DiscretizationConnection):
 
         return actx.einsum("ib,eb->ei",
                            quadrature_matrix(grp, mgrp),
-                           ary[grp.index],
+                           ary,
                            tagged=(FirstAxisIsElementsTag(),))
 
     def _compute_coeffs_via_inv_vandermonde(self, actx, ary, grp):
@@ -164,7 +164,7 @@ class NodalToModalDiscretizationConnection(DiscretizationConnection):
 
         return actx.einsum("ij,ej->ei",
                            vandermonde_inverse(grp),
-                           ary[grp.index],
+                           ary,
                            tagged=(FirstAxisIsElementsTag(),))
 
     def __call__(self, ary):
@@ -214,14 +214,14 @@ class NodalToModalDiscretizationConnection(DiscretizationConnection):
                                      "set `allow_approximate_quad=True`")
 
                 output = self._project_via_quadrature(
-                    actx, ary, grp, mgrp)
+                    actx, ary[igrp], grp, mgrp)
 
             # Handle all other interpolatory element groups by
             # inverting the Vandermonde matrix to compute the
             # modal coefficients
             elif isinstance(grp, InterpolatoryElementGroupBase):
                 output = self._compute_coeffs_via_inv_vandermonde(
-                    actx, ary, grp)
+                    actx, ary[igrp], grp)
             else:
                 raise NotImplementedError(
                     "Don't know how to project from group types "
@@ -344,7 +344,7 @@ class ModalToNodalDiscretizationConnection(DiscretizationConnection):
         result_data = tuple(
             actx.einsum("ib,eb->ei",
                         matrix(grp, self.from_discr.groups[igrp]),
-                        ary[grp.index],
+                        ary[igrp],
                         tagged=(FirstAxisIsElementsTag(),))
             for igrp, grp in enumerate(self.to_discr.groups)
         )

--- a/meshmode/discretization/connection/projection.py
+++ b/meshmode/discretization/connection/projection.py
@@ -217,7 +217,7 @@ class L2ProjectionInverseDiscretizationConnection(DiscretizationConnection):
                 c_batch_data.append(
                     actx.call_loopy(
                         kproj(),
-                        ary=ary[sgrp.index],
+                        ary=ary[batch.from_group_index],
                         basis_tabulation=tabulations,
                         weights=weights[igrp, ibatch],
                         from_element_indices=batch.to_element_indices,

--- a/meshmode/discretization/connection/refinement.py
+++ b/meshmode/discretization/connection/refinement.py
@@ -122,7 +122,7 @@ def make_refinement_connection(actx, refiner, coarse_discr, group_factory):
         with the mesh given to the refiner
 
     :arg group_factory: An instance of
-        :class:`meshmode.discretization.poly_element.ElementGroupFactory`. Used
+        :class:`meshmode.discretization.ElementGroupFactory`. Used
         for discretizing the fine mesh.
     """
     from meshmode.discretization.connection import (

--- a/meshmode/discretization/poly_element.py
+++ b/meshmode/discretization/poly_element.py
@@ -23,7 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from abc import abstractproperty
+from abc import abstractmethod
 from typing import ClassVar, Tuple
 from warnings import warn
 
@@ -289,7 +289,8 @@ class _MassMatrixQuadratureElementGroup(PolynomialSimplexElementGroupBase):
                          np.ones(len(basis_fcts)))
         return mp.Quadrature(nodes, weights, exact_to=self.order)
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def _interp_nodes(self):
         """Returns a :class:`numpy.ndarray` of shape ``(dim, nunit_dofs)``
         of interpolation nodes on the reference cell.

--- a/meshmode/discretization/poly_element.py
+++ b/meshmode/discretization/poly_element.py
@@ -695,7 +695,7 @@ class TypeMappingGroupFactory(ElementGroupFactory):
         :arg mesh_group_class_to_factory: a :class:`dict` from
             :class:`~meshmode.mesh.MeshElementGroup` subclasses to
             :class:`~meshmode.discretization.ElementGroupBase` subclasses or
-            :class:`~meshmode.discretization.poly_element.ElementGroupFactory`
+            :class:`~meshmode.discretization.ElementGroupFactory`
             instances.
         """
         super().__init__()

--- a/meshmode/interop/firedrake/connection.py
+++ b/meshmode/interop/firedrake/connection.py
@@ -623,7 +623,7 @@ def build_connection_from_firedrake(actx, fdrake_fspace, grp_factory=None,
         a mesh which is importable by
         :func:`~meshmode.interop.firedrake.mesh.import_firedrake_mesh`.
     :arg grp_factory: (optional) If not *None*, should be
-        a :class:`~meshmode.discretization.poly_element.ElementGroupFactory`
+        a :class:`~meshmode.discretization.ElementGroupFactory`
         whose group class is a subclass of
         :class:`~meshmode.discretization.InterpolatoryElementGroupBase`.
         If *None*, and a default factory is automatically selected.

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ def main():
               "arraycontext",
 
               "recursivenodes",
-              "dataclasses; python_version<='3.6'",
+              "dataclasses; python_version<'3.7'",
+              "typing_extensions; python_version<'3.8'",
               ],
           extras_require={
               "visualization": ["h5py"],


### PR DESCRIPTION
This deprecates the `index` attribute
* Set `index=None` in `ElementGroupBase` and issue a deprecation warning.
* Set `index=None` in `ElementGroupFactory.__call__` too.

The last two commits are independent and just do some random cleanup in `meshmode.discretization.__init__`. I can pluck those out into a separate PR if that's easier.

Second part of #224.