### PR TITLE
Add a way to visualize the mesh node-vertex resampling error

### DIFF
--- a/meshmode/mesh/__init__.py
+++ b/meshmode/mesh/__init__.py
@@ -1156,13 +1156,7 @@ class Mesh(Record):
 
 # {{{ node-vertex consistency test
 
-def _test_node_vertex_consistency_resampling(mesh, mgrp, tol):
-    if mesh.vertices is None:
-        return True
-
-    if mgrp.nelements == 0:
-        return True
-
+def _mesh_group_node_vertex_error(mesh, mgrp):
     if isinstance(mgrp, _ModepyElementGroup):
         basis = mp.basis_for_space(mgrp._modepy_space, mgrp._modepy_shape).functions
     else:
@@ -1173,15 +1167,25 @@ def _test_node_vertex_consistency_resampling(mesh, mgrp, tol):
             mgrp.vertex_unit_coordinates().T,
             mgrp.unit_nodes)
 
-    # dim, nelments, nnvertices
+    # dim, nelments, nvertices
     map_vertices = np.einsum(
             "ij,dej->dei", resampling_mat, mgrp.nodes)
-
     grp_vertices = mesh.vertices[:, mgrp.vertex_indices]
 
-    per_element_vertex_errors = np.sqrt(np.sum(
-            np.sum((map_vertices - grp_vertices)**2, axis=0),
-            axis=-1))
+    return map_vertices - grp_vertices
+
+
+def _test_node_vertex_consistency_resampling(mesh, mgrp, tol):
+    if mesh.vertices is None:
+        return True
+
+    if mgrp.nelements == 0:
+        return True
+
+    per_vertex_errors = _mesh_group_node_vertex_error(mesh, mgrp)
+    per_element_vertex_errors = np.sqrt(
+        np.sum(np.sum((per_vertex_errors)**2, axis=0), axis=-1)
+    )
 
     if tol is None:
         tol = 1e3 * np.finfo(per_element_vertex_errors.dtype).eps

--- a/test/test_visualization.py
+++ b/test/test_visualization.py
@@ -337,6 +337,25 @@ def test_vtk_overwrite(actx_factory):
 # }}}
 
 
+# {{{ test_visualize_mesh_resampling_error
+
+def test_visualize_mesh_resampling_error(actx_factory):
+    actx = actx_factory()
+    target_order = 4
+
+    import modepy as mp
+    quad = mp.VioreanuRokhlinSimplexQuadrature(target_order, 2)
+    mesh = mgen.generate_torus(5.0, 2.0, order=target_order,
+                               unit_nodes=quad.nodes,
+                               node_vertex_consistency_tolerance=False)
+
+    from meshmode.mesh.visualization import visualize_mesh_vertex_resampling_error
+    visualize_mesh_vertex_resampling_error(
+        actx, mesh, "visualize_resampling_error.vtu", overwrite=True)
+
+# }}}
+
+
 if __name__ == "__main__":
     import sys
     if len(sys.argv) > 1:


### PR DESCRIPTION
Used while looking at #310 yesterday and thought it may be useful. What do you think?

Added some types in a second commit, so probably best viewed individually.
