### PR TITLE
Work around accidental installation of 'external' flavor of c-f ompi

### DIFF
--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -24,8 +24,10 @@ dependencies:
 - pybind11
 
 # for MPI-based tests
-- openmpi
+# workaround for https://github.com/conda-forge/openmpi-feedstock/issues/94
+- openmpi<4.1.3
 - mpi4py
+- libgfortran5
 
 # for xdmf/hdf5 visualizer
 - h5py=*=mpi_openmpi*


### PR DESCRIPTION
- Works around https://github.com/conda-forge/openmpi-feedstock/issues/94
- Uses same workaround as https://github.com/conda-forge/lfpy-feedstock/pull/31/files