### PR TITLE
Revert "Work around accidental installation of 'external' flavor of cf-ompi"

### DIFF
--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -24,10 +24,8 @@ dependencies:
 - pybind11
 
 # for MPI-based tests
-# workaround for https://github.com/conda-forge/openmpi-feedstock/issues/94
-- openmpi<4.1.3
+- openmpi
 - mpi4py
-- libgfortran5
 
 # for xdmf/hdf5 visualizer
 - h5py=*=mpi_openmpi*


### PR DESCRIPTION
This reverts commit 5c5889aa48ca79d82c81e7e57f613a527c446a77.

Should no longer be needed because of https://github.com/conda-forge/openmpi-feedstock/pull/98.