### PR TITLE
Weaken mesh check in `make_same_mesh_connection`

### DIFF
--- a/meshmode/discretization/connection/same_mesh.py
+++ b/meshmode/discretization/connection/same_mesh.py
@@ -33,7 +33,7 @@ def make_same_mesh_connection(actx, to_discr, from_discr):
             IdentityDiscretizationConnection,
             DirectDiscretizationConnection)
 
-    if from_discr.mesh is not to_discr.mesh:
+    if from_discr.mesh != to_discr.mesh:
         raise ValueError("from_discr and to_discr must be based on "
                 "the same mesh")
 

--- a/meshmode/mesh/__init__.py
+++ b/meshmode/mesh/__init__.py
@@ -1177,6 +1177,8 @@ class Mesh(Record):
 
     def __eq__(self, other):
         return (
+            self is other
+            or (
                 type(self) == type(other)
                 and np.array_equal(self.vertices, other.vertices)
                 and self.groups == other.groups
@@ -1184,7 +1186,7 @@ class Mesh(Record):
                 and self.element_id_dtype == other.element_id_dtype
                 and self._nodal_adjacency == other._nodal_adjacency
                 and self._facial_adjacency_groups == other._facial_adjacency_groups
-                and self.is_conforming == other.is_conforming)
+                and self.is_conforming == other.is_conforming))
 
     def __ne__(self, other):
         return not self.__eq__(other)


### PR DESCRIPTION
Weakens the mesh check a bit to fix #358. Also adds an object identity check to the mesh `__eq__` so it doesn't need to compare all the attributes if the two mesh objects are actually the same one.