### PR TITLE
Add a simple piecewise C geometry

### DIFF
--- a/test/test_mesh.py
+++ b/test/test_mesh.py
@@ -419,11 +419,13 @@ def test_mesh_rotation(ambient_dim, visualize=False):
     order = 3
 
     if ambient_dim == 2:
-        nelements = 32
+        nelements = 256
         mesh = mgen.make_curve_mesh(
-                partial(mgen.ellipse, 2.0),
+                # partial(mgen.ellipse, 2.0),
+                partial(mgen.clamp_piecewise, 1.0, 2 / 3, np.pi / 6),
                 np.linspace(0.0, 1.0, nelements + 1),
                 order=order)
+
     elif ambient_dim == 3:
         mesh = mgen.generate_torus(4.0, 2.0, order=order)
     else:


### PR DESCRIPTION
This adds a piecewise construction, since that seemed easier. It looks like this:

<p align=center>
<img src="https://user-images.githubusercontent.com/777240/208290536-364f1608-7bd1-4fe4-a8e4-623453f48660.png" width="500"></img>
</p>

There's some knobs to control the radius of the outer circle, the inner circle and the size of the gap in front. It should only be C0 though. Do you think it's worth adding a Fourier interpolated smooth version?