### PR TITLE
_reshape_and_preserve_tags: support untaggable arrays

### DIFF
--- a/meshmode/discretization/connection/direct.py
+++ b/meshmode/discretization/connection/direct.py
@@ -48,10 +48,12 @@ from dataclasses import dataclass
 def _reshape_and_preserve_tags(
         actx: ArrayContext, ary: ArrayT, new_shape: Tuple[int, ...]) -> ArrayT:
     try:
-        return actx.tag(ary.tags, ary.reshape(new_shape))
+        tags = ary.tags
     except AttributeError:
         # 'ary' might not have a 'tags' attribute (e.g., in case of an np.ndarray)
         return ary.reshape(new_shape)
+    else:
+        return actx.tag(tags, ary.reshape(new_shape))
 
 
 # {{{ interpolation batch

--- a/meshmode/discretization/connection/direct.py
+++ b/meshmode/discretization/connection/direct.py
@@ -47,7 +47,10 @@ from dataclasses import dataclass
 
 def _reshape_and_preserve_tags(
         actx: ArrayContext, ary: ArrayT, new_shape: Tuple[int, ...]) -> ArrayT:
-    return actx.tag(ary.tags, ary.reshape(new_shape))
+    try:
+        return actx.tag(ary.tags, ary.reshape(new_shape))
+    except AttributeError:
+        return ary.reshape(new_shape)
 
 
 # {{{ interpolation batch

--- a/meshmode/discretization/connection/direct.py
+++ b/meshmode/discretization/connection/direct.py
@@ -50,6 +50,7 @@ def _reshape_and_preserve_tags(
     try:
         return actx.tag(ary.tags, ary.reshape(new_shape))
     except AttributeError:
+        # 'ary' might not have a 'tags' attribute (e.g., in case of an np.ndarray)
         return ary.reshape(new_shape)
 
 


### PR DESCRIPTION
(e.g. np.ndarray)

cc https://github.com/inducer/arraycontext/pull/235