### PR TITLE
Tensor product 1d nodes & basis functions

### DIFF
--- a/.ci/install-for-firedrake.sh
+++ b/.ci/install-for-firedrake.sh
@@ -5,10 +5,6 @@ sudo apt update
 sudo apt upgrade -y
 sudo apt install time
 
-# Otherwise we get missing CL symbols
-export PYOPENCL_CL_PRETEND_VERSION=2.1
-sudo apt install -y pocl-opencl-icd ocl-icd-opencl-dev
-
 . /home/firedrake/firedrake/bin/activate
 grep -v loopy requirements.txt > /tmp/myreq.txt
 
@@ -16,14 +12,14 @@ grep -v loopy requirements.txt > /tmp/myreq.txt
 sed -i "/boxtree/ d" /tmp/myreq.txt
 sed -i "/sumpy/ d" /tmp/myreq.txt
 sed -i "/pytential/ d" /tmp/myreq.txt
+sed -i "/pyopencl/ d" /tmp/myreq.txt
 
 # This shouldn't be necessary, but...
 # https://github.com/inducer/meshmode/pull/48#issuecomment-687519451
 pip install pybind11
-
 pip install pytest
-
 pip install -r /tmp/myreq.txt
+pip install pyopencl[pocl]
 
 # Context: https://github.com/OP2/PyOP2/pull/605
 python -m pip install --force-reinstall git+https://github.com/inducer/pytools.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,14 +150,13 @@ jobs:
             run: |
                 # texlive is needed for sphinxcontrib-tikz
                 sudo apt-get update
-                sudo apt-get install -y --no-install-recommends texlive-pictures
+                sudo apt-get install -y --no-install-recommends texlive-pictures graphviz pdf2svg
 
                 curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/ci-support.sh
                 . ci-support.sh
 
                 export EXTRA_INSTALL="sphinxcontrib-tikz"
                 build_py_project_in_conda_env
-                conda install graphviz pdf2svg
 
                 # Work around
                 # intersphinx inventory 'https://firedrakeproject.org/objects.inv' not fetchable

--- a/meshmode/discretization/connection/direct.py
+++ b/meshmode/discretization/connection/direct.py
@@ -700,7 +700,7 @@ class DirectDiscretizationConnection(DiscretizationConnection):
                                 from_element_indices[iel],
                                 dof_pick_lists[dof_pick_list_indices[iel], idof]
                             ]
-                        { if_present })
+                        {if_present})
                 """,
                 [
                     lp.GlobalArg("ary", None,

--- a/meshmode/mesh/__init__.py
+++ b/meshmode/mesh/__init__.py
@@ -513,6 +513,11 @@ class TensorProductElementGroup(_ModepyElementGroup):
     r"""Inherits from :class:`MeshElementGroup`."""
     _modepy_shape_cls: ClassVar[Type[mp.Shape]] = mp.Hypercube
 
+    def is_affine(self):
+        # Tensor product mappings are generically bilinear.
+        # FIXME: Are affinely mapped ones a 'juicy' enough special case?
+        return False
+
 # }}}
 
 


### PR DESCRIPTION
Without access to the 1D nodes and 1D basis functions used in the tensor product, we are not able to exploit the tensor product structure to reduce the cost required for operator evaluation, e.g. applying a differentiation operator to function data.

This PR:
- Adds functionality to `TensorProductElementGroupBase` to store and retrieve 1D basis functions and 1D nodes used in the tensor product
- Updates subclasses accordingly

Depends on:
- [x] https://github.com/inducer/modepy/pull/72