### PR TITLE
DOFArray: support untaggable arrays in setstate

### DIFF
--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -333,7 +333,12 @@ class DOFArray:
             assert len(axes_tags[idx]) == ary.ndim
             assert isinstance(axes_tags[idx], list)
 
-            d = actx.from_numpy(ary)._with_new_tags(tags[idx])
+            try:
+                d = actx.from_numpy(ary)._with_new_tags(tags[idx])
+            except AttributeError:
+                # 'actx.from_numpy' might return an array that does not have
+                # '_with_new_tags' (e.g., np.ndarray).
+                d = actx.from_numpy(ary)
 
             for ida, ax in enumerate(axes_tags[idx]):
                 d = actx.tag_axis(ida, ax, d)

--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -333,12 +333,14 @@ class DOFArray:
             assert len(axes_tags[idx]) == ary.ndim
             assert isinstance(axes_tags[idx], list)
 
+            d = actx.from_numpy(ary)
+
             try:
-                d = actx.from_numpy(ary)._with_new_tags(tags[idx])
+                d = d._with_new_tags(tags[idx])
             except AttributeError:
                 # 'actx.from_numpy' might return an array that does not have
                 # '_with_new_tags' (e.g., np.ndarray).
-                d = actx.from_numpy(ary)
+                pass
 
             for ida, ax in enumerate(axes_tags[idx]):
                 d = actx.tag_axis(ida, ax, d)


### PR DESCRIPTION
This ~~should fix~~ fixes restart with Numpy actx. cc @MTCam 