### PR TITLE
Allow passing scalars (and containers of scalars) to `DirectDiscretizationConnection`

### DIFF
--- a/meshmode/discretization/connection/direct.py
+++ b/meshmode/discretization/connection/direct.py
@@ -596,7 +596,10 @@ class DirectDiscretizationConnection(DiscretizationConnection):
 
         # {{{ recurse into array containers
 
-        if not isinstance(ary, DOFArray):
+        from numbers import Number
+        if isinstance(ary, Number):
+            return ary
+        elif not isinstance(ary, DOFArray):
             try:
                 iterable = serialize_container(ary)
             except NotAnArrayContainerError:


### PR DESCRIPTION
`project(...)` in grudge currently fails when passed an object array of numbers, because it only checks whether the entire input is a number ([code](https://github.com/inducer/grudge/blob/4cab8a846c447bbcd48f2872eb476d77a6bd9840/grudge/projection.py#L81)), not whether it's an array container of them. Checking down inside `DirectDiscretizationConnection` instead fixes that.