### PR TITLE
ci: fix tikz generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,8 @@ jobs:
             run: |
                 # texlive is needed for sphinxcontrib-tikz
                 sudo apt-get update
-                sudo apt-get install -y --no-install-recommends texlive-pictures graphviz pdf2svg
+                sudo apt-get install -y --no-install-recommends \
+                    texlive-pictures texlive-latex-extra graphviz pdf2svg
 
                 curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/ci-support.sh
                 . ci-support.sh


### PR DESCRIPTION
The CI was complaining that there's no `standalone.cls` when building tikz pictures.
https://github.com/inducer/meshmode/actions/runs/8585855922/job/23527696674

This installs `texlive-latex-extra` to fix that. At least that's where `standalone.cls` is on Arch, so fingers crossed :worried: 