### PR TITLE
Improve mesh consistency check

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,10 +16,9 @@ tikz_tikzlibraries = "decorations.markings"
 copyright = "2014-21, Meshmode contributors"
 
 ver_dic = {}
-exec(
-        compile(
-            open("../meshmode/version.py").read(), "../meshmode/version.py", "exec"),
-        ver_dic)
+with open("../meshmode/version.py") as _inf:
+    exec(compile(_inf.read(), "../meshmode/version.py", "exec"), ver_dic)
+
 version = ".".join(str(x) for x in ver_dic["VERSION"])
 # The full version, including alpha/beta/rc tags.
 release = ver_dic["VERSION_TEXT"]

--- a/meshmode/__init__.py
+++ b/meshmode/__init__.py
@@ -22,10 +22,13 @@ THE SOFTWARE.
 
 
 __doc__ = """
-.. exception:: Error
-.. exception:: DataUnavailable
-.. exception:: FileExistsError
-.. exception:: InconsistentVerticesError
+.. autoexception:: Error
+.. autoexception:: DataUnavailableError
+
+.. autoexception:: InconsistentMeshError
+.. autoexception:: InconsistentArrayDTypeError
+.. autoexception:: InconsistentVerticesError
+.. autoexception:: InconsistentAdjacencyError
 """
 
 from builtins import FileExistsError  # noqa: F401
@@ -34,19 +37,42 @@ from meshmode.mesh.tools import AffineMap  # noqa: F401
 
 
 class Error(RuntimeError):
-    pass
+    """Exception base for :mod:`meshmode` errors."""
 
 
-class DataUnavailable(Error):
-    pass
+class DataUnavailableError(Error):
+    """Raised when some data on the mesh or the discretization is not available.
 
-
-class InconsistentVerticesError(Error):
+    This error should not be raised when the specific data simply fails to be
+    computed for other reasons.
     """
-    Raised when an element's local-to-global mapping does not map the unit vertices
-    to the corresponding values in the mesh's *vertices* array.
+
+
+DataUnavailable = DataUnavailableError
+
+
+class InconsistentMeshError(Error):
+    """Raised when the mesh is inconsistent in some fashion.
+
+    Prefer the more specific exceptions, e.g. :exc:`InconsistentVerticesError`
+    when possible.
     """
-    pass
+
+
+class InconsistentArrayDTypeError(InconsistentMeshError):
+    """Raised when a mesh (or group) array does not match the provided
+    :class:`~numpy.dtype`.
+    """
+
+
+class InconsistentVerticesError(InconsistentMeshError):
+    """Raised when an element's local-to-global mapping does not map the unit
+    vertices to the corresponding values in the mesh's *vertices* array.
+    """
+
+
+class InconsistentAdjacencyError(InconsistentMeshError):
+    """Raised when the nodal or the facial adjacency is inconsistent."""
 
 
 def _acf():

--- a/meshmode/mesh/io.py
+++ b/meshmode/mesh/io.py
@@ -441,12 +441,12 @@ def to_json(mesh):
             "dim": group.dim,
             }
 
-    from meshmode import DataUnavailable
+    from meshmode import DataUnavailableError
 
     def nodal_adjacency_to_json(mesh):
         try:
             na = mesh.nodal_adjacency
-        except DataUnavailable:
+        except DataUnavailableError:
             return None
 
         return {


### PR DESCRIPTION
Small followup to #400: this makes `check_mesh_consistency` raise some helpful exceptions with more details about what the inconsistency is, instead of just using `assert`.

The check in `make_mesh` is still only done `if __debug__` though.