### PR TITLE
Fix warnings and deprecations

### DIFF
--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -1230,7 +1230,12 @@ class Visualizer:
             while len(nodes) < 3:
                 nodes.append(0*nodes[0])
 
-            from matplotlib.tri.triangulation import Triangulation
+            try:
+                from matplotlib.tri import Triangulation
+            except ImportError:
+                # NOTE: deprecated starting with v3.7
+                from matplotlib.tri.triangulation import Triangulation
+
             tri, _, kwargs = \
                 Triangulation.get_from_args_and_kwargs(
                         *nodes,

--- a/meshmode/mesh/processing.py
+++ b/meshmode/mesh/processing.py
@@ -1359,7 +1359,10 @@ def glue_mesh_boundaries(
 
     return mesh.copy(
         nodal_adjacency=False,
-        facial_adjacency_groups=facial_adjacency_groups)
+        _facial_adjacency_groups=tuple([
+            tuple(fagrps) for fagrps in facial_adjacency_groups
+            ]),
+        )
 
 # }}}
 
@@ -1403,7 +1406,8 @@ def map_mesh(mesh: Mesh, f: Callable[[np.ndarray], np.ndarray]) -> Mesh:
     # }}}
 
     return mesh.copy(
-            vertices=vertices, groups=new_groups,
+            vertices=vertices,
+            groups=tuple(new_groups),
             is_conforming=mesh.is_conforming)
 
 # }}}
@@ -1499,8 +1503,11 @@ def affine_map(
     # }}}
 
     return mesh.copy(
-            vertices=vertices, groups=new_groups,
-            facial_adjacency_groups=facial_adjacency_groups,
+            vertices=vertices,
+            groups=tuple(new_groups),
+            _facial_adjacency_groups=tuple([
+                tuple(fagrps) for fagrps in facial_adjacency_groups
+                ]) if facial_adjacency_groups is not None else None,
             is_conforming=mesh.is_conforming)
 
 

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -30,6 +30,7 @@ from arraycontext import (
     dataclass_array_container, pytest_generate_tests_for_array_contexts,
     with_container_arithmetic)
 from pytools.obj_array import make_obj_array
+from pytools.tag import Tag
 
 from meshmode import _acf  # noqa: F401
 from meshmode.array_context import (
@@ -48,7 +49,9 @@ pytest_generate_tests = pytest_generate_tests_for_array_contexts(
 
 # {{{ test_flatten_unflatten
 
-@with_container_arithmetic(bcast_obj_array=False, rel_comparison=True)
+@with_container_arithmetic(bcast_obj_array=False,
+                           rel_comparison=True,
+                           _cls_has_array_context_attr=True)
 @dataclass_array_container
 @dataclass(frozen=True)
 class MyContainer:
@@ -180,9 +183,6 @@ def test_dof_array_pickling(actx_factory):
 
     assert actx.to_numpy(flat_norm(mat_of_dofs - mat2_of_dofs, np.inf)) == 0
     assert actx.to_numpy(flat_norm(dc_of_dofs - dc2_of_dofs, np.inf)) == 0
-
-
-from pytools.tag import Tag
 
 
 class FooTag(Tag):

--- a/test/test_meshmode.py
+++ b/test/test_meshmode.py
@@ -562,7 +562,7 @@ def test_sanity_single_element(actx_factory, dim, mesh_order, group_cls,
     # {{{ volume calculation check
 
     if isinstance(mg, SimplexElementGroup):
-        from pytools import factorial
+        from math import factorial
         true_vol = 1/factorial(dim) * 2**dim
     elif isinstance(mg, TensorProductElementGroup):
         true_vol = 2**dim


### PR DESCRIPTION
There's still a bunch of warnings about SVM memory like
```
<generated code for 'invoke_frozen_nodes1_2d_loopy_kernel'>:131: InconsistentOpenCLQueueWarning: Array has different queue from backing SVM memory. This may lead to the array getting deallocated sooner than expected, potentially leading to crashes.
```
and some more loopy warnings, but everything else should be clean.