### PR TITLE
Switch to meshmode actx in `test_mpi_communication`

### DIFF
--- a/test/test_partition.py
+++ b/test/test_partition.py
@@ -397,7 +397,7 @@ def _test_mpi_boundary_swap(dim, order, num_groups):
 
     group_factory = default_simplex_group_factory(base_dim=dim, order=order)
 
-    from arraycontext import PyOpenCLArrayContext
+    from meshmode.array_context import PyOpenCLArrayContext
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(queue, force_device_scalars=True)


### PR DESCRIPTION
Should fix CI failures like https://gitlab.tiker.net/inducer/meshmode/-/jobs/714915.