### PR TITLE
Fix issues with ruff 0.5.7

### DIFF
--- a/meshmode/distributed.py
+++ b/meshmode/distributed.py
@@ -377,7 +377,7 @@ class MPIBoundaryCommSetupHelper:
                         group_factory=self.bdry_grp_factory),
                     remote_group_infos=remote_group_infos))
 
-            del self.pending_recv_identifiers[(local_part_id, remote_part_id)]
+            del self.pending_recv_identifiers[local_part_id, remote_part_id]
 
         assert not self.pending_recv_identifiers
         MPI.Request.waitall(self.send_reqs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ extend-select = [
     "W",    # pycodestyle
 ]
 extend-ignore = [
+    "C409", # remove comprehension within tuple call
     "C90",  # McCabe complexity
     "E226", # missing whitespace around arithmetic operator
     "E241", # multiple spaces after comma

--- a/test/test_firedrake_interop.py
+++ b/test/test_firedrake_interop.py
@@ -420,7 +420,7 @@ def test_from_fd_transfer(actx_factory, fspace_degree,
     eoc_recorders = {(True, d): EOCRecorder() for d in range(dim)}
     if not only_convert_bdy:
         for d in range(dim):
-            eoc_recorders[(False, d)] = EOCRecorder()
+            eoc_recorders[False, d] = EOCRecorder()
 
     def get_fdrake_mesh_and_h_from_par(mesh_par):
         from firedrake import Mesh, UnitCubeMesh, UnitIntervalMesh, UnitSquareMesh
@@ -500,7 +500,7 @@ def test_from_fd_transfer(actx_factory, fspace_degree,
 
             # record fd -> mm error
             err = np.max(np.abs(fd2mm_f - meshmode_f))
-            eoc_recorders[(True, d)].add_data_point(h, err)
+            eoc_recorders[True, d].add_data_point(h, err)
 
             if not only_convert_bdy:
                 # now transport mm -> fd
@@ -509,7 +509,7 @@ def test_from_fd_transfer(actx_factory, fspace_degree,
                 mm2fd_f = fdrake_connection.from_meshmode(meshmode_f_dofarr)
                 # record mm -> fd error
                 err = np.max(np.abs(fdrake_f.dat.data - mm2fd_f.dat.data))
-                eoc_recorders[(False, d)].add_data_point(h, err)
+                eoc_recorders[False, d].add_data_point(h, err)
 
     # assert that order is correct or error is "low enough"
     for ((fd2mm, d), eoc_rec) in eoc_recorders.items():


### PR DESCRIPTION
This adds an ignore for https://docs.astral.sh/ruff/rules/unnecessary-literal-within-tuple-call/, since I don't think we want to use generators in tuple calls.

Setting `preview = true` might have been a bit optimistic. They seem to still make a lot of changes in that area even for established rules :\