### PR TITLE
Remove uses of deprecated `force_device_scalars=False`

### DIFF
--- a/meshmode/array_context.py
+++ b/meshmode/array_context.py
@@ -273,13 +273,6 @@ class PytestPyOpenCLArrayContextFactory(
     actx_class = PyOpenCLArrayContext
 
 
-# deprecated
-class PytestPyOpenCLArrayContextFactoryWithHostScalars(
-        _PytestPyOpenCLArrayContextFactoryWithClass):
-    actx_class = PyOpenCLArrayContext
-    force_device_scalars = False
-
-
 class PytestPytatoPyOpenCLArrayContextFactory(
         _PytestPytatoPyOpenCLArrayContextFactory):
 
@@ -290,8 +283,6 @@ class PytestPytatoPyOpenCLArrayContextFactory(
 
 register_pytest_array_context_factory("meshmode.pyopencl",
         PytestPyOpenCLArrayContextFactory)
-register_pytest_array_context_factory("meshmode.pyopencl-deprecated",
-        PytestPyOpenCLArrayContextFactoryWithHostScalars)
 register_pytest_array_context_factory("meshmode.pytato_cl",
         PytestPytatoPyOpenCLArrayContextFactory)
 


### PR DESCRIPTION
In preparation for inducer/arraycontext#278.