### PR TITLE
Skip element orientation test for face meshes

### DIFF
--- a/meshmode/discretization/connection/face.py
+++ b/meshmode/discretization/connection/face.py
@@ -356,7 +356,10 @@ def make_face_restriction(
                         unit_nodes=bdry_unit_nodes)
                 bdry_mesh_groups.append(bdry_mesh_group)
 
-    bdry_mesh = make_mesh(bdry_vertices, bdry_mesh_groups)
+    bdry_mesh = make_mesh(
+        bdry_vertices, bdry_mesh_groups,
+        # Element orientation test doesn't work if dim != ambient_dim
+        skip_element_orientation_test=True)
 
     bdry_discr = discr.copy(
             actx=actx,


### PR DESCRIPTION
The test only works if `mesh.dim == mesh.ambient_dim`, so it always ends up emitting a warning in the `make_mesh` call here.