### PR TITLE
Add LGL quadrature to TP LGL element group

### DIFF
--- a/meshmode/discretization/poly_element.py
+++ b/meshmode/discretization/poly_element.py
@@ -592,7 +592,14 @@ class LegendreGaussLobattoTensorProductElementGroup(
         unit_nodes_1d = legendre_gauss_lobatto_nodes(order)
         unit_nodes = mp.tensor_product_nodes([unit_nodes_1d]*mesh_el_group.dim)
 
+        self._quadrature_rule = mp.LegendreGaussLobattoTensorProductQuadrature(
+            order, mesh_el_group.dim)
+
         super().__init__(mesh_el_group, order, unit_nodes=unit_nodes)
+
+    @memoize_method
+    def quadrature_rule(self):
+        return self._quadrature_rule
 
     def discretization_key(self):
         return (type(self), self.dim, self.order)


### PR DESCRIPTION
~~Docstring for `LegendreGaussLobattoTensorProductElementGroup` states it comes equipped with a high-order quadrature rule. However, it's not actually defined in the class so the default (not high-order) quadrature rule is used, i.e.~~
https://github.com/inducer/meshmode/blob/75c8fa8c66cdaf405835f56bed9d9c47ece08ed7/meshmode/discretization/poly_element.py#L526-L533

~~This PR adds tensor-product LGL quadrature from modepy to `LegendreGaussLobattoTensorProductElementGroup` as a quadrature rule.~~

EDIT: Disregard. The quadrature rule is correctly built using the method above. There is still an issue obtaining 1D quadratures (which I did not mention initially) in the current state of `LegendreGaussLobattoTensorProductElementGroup`, but I'll create another PR for that.