### PR TITLE
Use `TensorProductQuadrature` instead of `Quadrature` in `TensorProductElementGroupBase`

### DIFF
--- a/meshmode/discretization/poly_element.py
+++ b/meshmode/discretization/poly_element.py
@@ -525,12 +525,14 @@ class TensorProductElementGroupBase(PolynomialElementGroupBase,
 
     @memoize_method
     def quadrature_rule(self):
-        basis = self._basis
-        nodes = self._nodes
+        basis = self._basis.bases[0]
+        nodes = self.unit_nodes_1d
         mass_matrix = mp.mass_matrix(basis, nodes)
         weights = np.dot(mass_matrix,
                          np.ones(len(basis.functions)))
-        return mp.Quadrature(nodes, weights, exact_to=self.order)
+        quads = (mp.Quadrature(nodes, weights, exact_to=self.order),)*self.dim
+
+        return mp.TensorProductQuadrature(quads)
 
     @property
     @memoize_method

--- a/meshmode/discretization/poly_element.py
+++ b/meshmode/discretization/poly_element.py
@@ -534,9 +534,7 @@ class TensorProductElementGroupBase(PolynomialElementGroupBase,
         else:
             nodes_tp = self._nodes
 
-        for idim, zipped in enumerate(zip(nodes_tp, self._basis.bases)):
-            nodes, basis = zipped
-
+        for idim, (nodes, basis) in enumerate(zip(nodes_tp, self._basis.bases)):
             # get current dimension's nodes from fastest varying axis
             if self.dim != 1:
                 nodes = np.swapaxes(nodes, 0, idim)[:, *(0,)*(self.dim-1)]

--- a/meshmode/discretization/poly_element.py
+++ b/meshmode/discretization/poly_element.py
@@ -539,7 +539,7 @@ class TensorProductElementGroupBase(PolynomialElementGroupBase,
 
             # get current dimension's nodes from fastest varying axis
             if self.dim != 1:
-                nodes = np.swapaxes(nodes, 0, idim)[:,*(0,)*(self.dim-1)]
+                nodes = np.swapaxes(nodes, 0, idim)[:, *(0,)*(self.dim-1)]
 
             nodes_1d = nodes.reshape(1, -1)
             mass_matrix = mp.mass_matrix(basis, nodes_1d)


### PR DESCRIPTION
Attempting to access the 1D quadratures of the default quadrature rule supplied in `TensorProductElementGroupBase` is not possible. 

This PR makes it so that a `TensorProductQuadrature` is constructed from 1D `Quadrature`s using the 1D interpolation nodes and 1D basis functions associated with `TensorProductElementGroupBase`.