### PR TITLE
Make indexing compatible with py3.10

### DIFF
--- a/meshmode/discretization/poly_element.py
+++ b/meshmode/discretization/poly_element.py
@@ -536,8 +536,9 @@ class TensorProductElementGroupBase(PolynomialElementGroupBase,
             nodes_tp = self._nodes
 
         for idim, (nodes, basis) in enumerate(zip(nodes_tp, self._basis.bases)):
-            # get current dimension's nodes from fastest varying axis
-            nodes = nodes[*(0,)*idim, :, *(0,)*(self.dim-idim-1)]
+            # get current dimension's nodes
+            iaxis = (*(0,)*idim, slice(None), *(0,)*(self.dim-idim-1))
+            nodes = nodes[iaxis]
 
             nodes_1d = nodes.reshape(1, -1)
             mass_matrix = mp.mass_matrix(basis, nodes_1d)


### PR DESCRIPTION
Didn't catch this yesterday, but expanding tuples inside `ary[...]` is only allowed for >3.10. I think this should be equivalent.

cc @a-alveyblanc 