### PR TITLE
Optimize `generate_box_mesh`

### DIFF
--- a/meshmode/discretization/connection/direct.py
+++ b/meshmode/discretization/connection/direct.py
@@ -422,11 +422,16 @@ class DirectDiscretizationConnection(DiscretizationConnection):
         ibatch = self.groups[to_group_index].batches[ibatch_index]
         from_grp = self.from_discr.groups[ibatch.from_group_index]
 
-        from meshmode.mesh.tools import find_point_permutation
-        return find_point_permutation(
-                    targets=ibatch.result_unit_nodes,
-                    permutees=from_grp.unit_nodes,
+        from meshmode.mesh.tools import find_point_to_point_mapping
+        src_idx_to_tgt_idx = find_point_to_point_mapping(
+                    src_points=ibatch.result_unit_nodes,
+                    tgt_points=from_grp.unit_nodes,
                     tol_multiplier=tol_multiplier)
+
+        return (
+            src_idx_to_tgt_idx
+            if np.all(src_idx_to_tgt_idx >= 0)
+            else None)
 
     @keyed_memoize_method(lambda actx, to_group_index, ibatch_index,
             tol_multiplier=None: (to_group_index, ibatch_index, tol_multiplier))


### PR DESCRIPTION
Reimplements `generate_box_mesh` using numpy, and rearranges some of the boundary processing code to make it faster.

Before (shock1d):
<img width="979" alt="Screenshot 2025-04-17 at 12 51 27 PM" src="https://github.com/user-attachments/assets/7bf380a4-a26c-4867-a02c-1a043972053d" />

After:
<img width="973" alt="Screenshot 2025-04-17 at 12 51 50 PM" src="https://github.com/user-attachments/assets/ee6fc3a5-72ab-4ae6-a899-02087a5925b7" />

Fixes #456.

To-do:
- [x] Test against mirgecom examples/tests after `find_point_permutation` refactor
- [x] Re-do shock1d profile after `find_point_permutation` refactor