### PR TITLE
Remove deprecated keyword in mesh.generation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -2,8 +2,7 @@ from importlib import metadata
 from urllib.request import urlopen
 
 
-_conf_url = \
-        "https://raw.githubusercontent.com/inducer/sphinxconfig/main/sphinxconfig.py"
+_conf_url = "https://raw.githubusercontent.com/inducer/sphinxconfig/main/sphinxconfig.py"
 with urlopen(_conf_url) as _inf:
     exec(compile(_inf.read(), _conf_url, "exec"), globals())
 
@@ -19,9 +18,9 @@ release = metadata.version("meshmode")
 version = ".".join(release.split(".")[:2])
 
 intersphinx_mapping = {
+    "FInAT": ("https://finat.github.io/FInAT/", None),
     "arraycontext": ("https://documen.tician.de/arraycontext", None),
     "fenics": ("https://fenics.readthedocs.io/projects/fiat/en/latest", None),
-    "FInAT": ("https://finat.github.io/FInAT/", None),
     "firedrake": ("https://www.firedrakeproject.org", None),
     "gmsh_interop": ("https://documen.tician.de/gmsh_interop", None),
     "h5py": ("https://docs.h5py.org/en/stable", None),
@@ -36,6 +35,34 @@ intersphinx_mapping = {
     "pytools": ("https://documen.tician.de/pytools", None),
     "recursivenodes": ("https://tisaac.gitlab.io/recursivenodes", None),
 }
+
+sphinxconfig_missing_reference_aliases = {
+    # numpy
+    "DTypeLike": "obj:numpy.typing.DTypeLike",
+    "NDArray": "obj:numpy.typing.NDArray",
+    "np.bool": "class:numpy.bool",
+    "np.complexfloating": "class:numpy.complexfloating",
+    "np.floating": "class:numpy.floating",
+    "np.random.Generator": "class:numpy.random.Generator",
+    # pytools
+    "ObjectArray": "class:pytools.obj_array.ObjectArray",
+    # modepy
+    "ArrayF": "obj:modepy.typing.ArrayF",
+    # arraycontext
+    "Array": "class:arraycontext.Array",
+    "ArrayContext": "class:arraycontext.ArrayContext",
+    "ArrayOrContainerOrScalar": "obj:arraycontext.ArrayOrContainerOrScalar",
+    "arraycontext.typing.ArrayOrContainerOrScalarT":
+        "obj:arraycontext.ArrayOrContainerOrScalarT",
+    "arraycontext.typing.ArrayT": "obj:arraycontext.ArrayT",
+    # meshmode
+    "_DOFArray": "class:meshmode.dof_array.DOFArray",
+    "_MeshElementGroup": "class:meshmode.mesh.MeshElementGroup",
+}
+
+
+def setup(app):
+    app.connect("missing-reference", process_autodoc_missing_reference)  # noqa: F821
 
 
 # Some modules need to import things just so that sphinx can resolve symbols in

--- a/doc/misc.rst
+++ b/doc/misc.rst
@@ -106,36 +106,3 @@ AK also gratefully acknowledges a hardware gift from Nvidia Corporation.
 
 The views and opinions expressed herein do not necessarily reflect those of the
 funding agencies.
-
-References
-----------
-
-.. class:: ArrayContext
-
-    See :class:`arraycontext.ArrayContext`.
-
-.. class:: _Mesh
-
-    See :class:`meshmode.mesh.Mesh`.
-
-.. class:: _MeshElementGroup
-
-    See :class:`meshmode.mesh.MeshElementGroup`.
-
-.. class:: _DOFArray
-
-    See :class:`meshmode.dof_array.DOFArray`.
-
-.. class:: DTypeLike
-
-    See :data:`numpy.typing.DTypeLike`.
-
-.. currentmodule:: np
-
-.. class:: dtype
-
-    See :class:`numpy.dtype`.
-
-.. class:: complexfloating
-
-    See :class:`numpy.complexfloating`.

--- a/meshmode/discretization/__init__.py
+++ b/meshmode/discretization/__init__.py
@@ -84,13 +84,6 @@ Discretization class
 
 .. autofunction:: num_reference_derivative
 .. autoclass:: Discretization
-
-References
-----------
-
-.. class:: ObjectArray
-
-    See :class:`pytools.obj_array.ObjectArray`.
 """
 
 

--- a/meshmode/discretization/connection/__init__.py
+++ b/meshmode/discretization/connection/__init__.py
@@ -132,27 +132,6 @@ Implementation details
 .. autoclass:: InterpolationBatch
 
 .. autoclass:: DiscretizationConnectionElementGroup
-
-References
-----------
-
-.. currentmodule:: arraycontext.typing
-
-.. class:: ArrayT
-
-    See :class:`arraycontext.ArrayT`.
-
-.. class:: ArrayOrContainerT
-
-    See :class:`arraycontext.ArrayOrContainerT`.
-
-.. class:: ArrayOrContainerOrScalar
-
-    See :attr:`arraycontext.ArrayOrContainerOrScalar`.
-
-.. class:: ArrayOrContainerOrScalarT
-
-    See :class:`arraycontext.ArrayOrContainerOrScalarT`.
 """
 
 

--- a/meshmode/discretization/poly_element.py
+++ b/meshmode/discretization/poly_element.py
@@ -115,13 +115,6 @@ Type-based group factories
 .. autoclass:: InterpolatoryEquidistantGroupFactory
 .. autoclass:: QuadratureGroupFactory
 .. autoclass:: ModalGroupFactory
-
-Typing references
------------------
-
-.. class:: ArrayF
-
-    See :attr:`modepy.typing.ArrayF`.
 """
 
 

--- a/meshmode/discretization/visualization.py
+++ b/meshmode/discretization/visualization.py
@@ -73,13 +73,6 @@ __doc__ = """
 .. autoclass:: Visualizer
 
 .. autofunction:: write_nodal_adjacency_vtk_file
-
-
-References
-----------
-.. class:: Array
-
-    See :class:`arraycontext.Array`.
 """
 
 

--- a/meshmode/mesh/generation.py
+++ b/meshmode/mesh/generation.py
@@ -31,7 +31,7 @@ import numpy as np
 import numpy.linalg as la
 
 import modepy as mp
-from pytools import deprecate_keyword, log_process
+from pytools import log_process
 
 from meshmode.mesh import Mesh, MeshElementGroup, make_mesh
 
@@ -459,7 +459,6 @@ def make_curve_mesh(
 
 # {{{ make_group_from_vertices
 
-@deprecate_keyword("group_factory", "group_cls")
 def make_group_from_vertices(
         vertices: np.ndarray, vertex_indices: np.ndarray, order: int, *,
         group_cls: type[MeshElementGroup] | None = None,
@@ -1142,7 +1141,6 @@ def generate_urchin(
 
 # {{{ generate_box_mesh
 
-@deprecate_keyword("group_factory", "group_cls")
 def generate_box_mesh(
         axis_coords: tuple[np.ndarray, ...],
         order: int = 1, *,
@@ -1593,7 +1591,6 @@ def generate_box_mesh(
 
 # {{{ generate_regular_rect_mesh
 
-@deprecate_keyword("group_factory", "group_cls")
 def generate_regular_rect_mesh(
         a: Sequence[float] = (0, 0),
         b: Sequence[float] = (1, 1), *,

--- a/meshmode/mesh/refinement/__init__.py
+++ b/meshmode/mesh/refinement/__init__.py
@@ -40,19 +40,6 @@ __doc__ = """
 .. autoclass:: Refiner
 .. autoclass :: RefinerWithoutAdjacency
 .. autofunction :: refine_uniformly
-
-References
-----------
-
-.. class:: NDArray
-
-    See :data:`numpy.typing.NDArray`
-
-.. currentmodule:: np
-
-.. class:: bool
-
-    See :class:`np.bool`.
 """
 
 __all__ = [


### PR DESCRIPTION
This didn't have a deadline, but they were deprecated in 2020 (from `git blame`) and there are no uses of the old behavior in `pytential`, `grudge`, etc.