### PR TITLE
Remove unused ruff noqa

### DIFF
--- a/meshmode/dof_array.py
+++ b/meshmode/dof_array.py
@@ -436,7 +436,7 @@ def _deserialize_dof_container(
         return type(template)(
                 template.array_context,
                 # NOTE: tuple([]) is faster, and this is a cost-sensitive code path.
-                data=tuple([v for _i, v in iterable]))  # noqa: C409
+                data=tuple([v for _i, v in iterable]))
 
 
 @with_array_context.register(DOFArray)


### PR DESCRIPTION
Also, it seems like this got optimized in Python 3.14, so it may no longer be an issue either way.

xref: https://github.com/astral-sh/ruff/pull/25707